### PR TITLE
Implement xformers layernorm (2x faster than nn.LayerNorm)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requirements = [
     "torch>=2.0.0",
     "transformers>=4.32.0",
     "tokenizers>=0.12.1",
+    "xformers>=0.0.21",
     "accelerate",
     "sentencepiece",
     "lm_eval",


### PR DESCRIPTION
The `xformers` LayerNorm is roughly 2x faster than `nn.LayerNorm`. I choose to implement this on the MPT model, yet it seems performance is bottlenecked by the slower CPU that I rented.

I also tested the FasterTransformer LayerNorm, but it was the same speed as `nn.LayerNorm`.

EDIT: Resolves #2 