### PR TITLE
YaRN support for LLaMa models

### DIFF
--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -316,7 +316,13 @@ class BaseAWQForCausalLM(nn.Module):
             
             # Load model weights
             model = AutoModelForCausalLM.from_pretrained(
-                model_filename, device_map=device_map, offload_folder="offload", offload_state_dict=True, torch_dtype=torch_dtype, use_safetensors=safetensors
+                model_filename, 
+                device_map=device_map, 
+                trust_remote_code=trust_remote_code, 
+                offload_folder="offload", 
+                offload_state_dict=True, 
+                torch_dtype=torch_dtype, 
+                use_safetensors=safetensors
             )
             model.eval()
 


### PR DESCRIPTION
Quantization works on YaRN models:
https://huggingface.co/casperhansen/yarn-llama-2-7b-64k-awq

Investigate:
- seems YaRN is not getting the speedup from fused layers in LLaMa (probably due to custom code not yet implemented in huggingface transformers)
- the perplexity of 8.9359 seem too good to be true? vicuna 7b v1.5 has 11.7193 in perplexity.