### PR TITLE
Support Falcon 180B

### DIFF
--- a/awq/models/auto.py
+++ b/awq/models/auto.py
@@ -8,6 +8,7 @@ AWQ_CAUSAL_LM_MODEL_MAP = {
     "opt": OptAWQForCausalLM,
     "RefinedWeb": FalconAWQForCausalLM,
     "RefinedWebModel": FalconAWQForCausalLM,
+    "falcon": FalconAWQForCausalLM,
     "bloom": BloomAWQForCausalLM,
     "gptj": GPTJAWQForCausalLM
 }


### PR DESCRIPTION
This is a small change to support loading and quanting Falcon 180B based on the new `config.json`. This should support the new model, but it is untested as I do not have a large cluster to test with.