### PR TITLE
Fix KV cache shapes error

### DIFF
--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -190,15 +190,8 @@ class QuantAttentionFused(nn.Module):
                 .contiguous()
             )
             
-            try:
-                self.cache_v[:bsz, :, self.start_pos : self.start_pos + seqlen, :] = values_store
-                self.cache_k[:bsz, :, :, self.start_pos : self.start_pos + seqlen, :] = keys_store
-            except Exception as ex:
-                print(seqlen, self.max_seq_len)
-                print(self.cache_v.shape, self.cache_v[:bsz, :, self.start_pos : self.start_pos + seqlen, :].shape, values_store.shape)
-                print(self.cache_k.shape, self.cache_k[:bsz, :, :, self.start_pos : self.start_pos + seqlen, :].shape, keys_store.shape)
-                print(ex)
-                exit(0)
+            self.cache_v[:bsz, :, self.start_pos : self.start_pos + seqlen, :] = values_store
+            self.cache_k[:bsz, :, :, self.start_pos : self.start_pos + seqlen, :] = keys_store
 
             if seqlen == 1:
                 xv = self.cache_v[:bsz, :, : self.start_pos + seqlen, :].transpose(1, 2).contiguous()

--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -84,7 +84,8 @@ class QuantAttentionFused(nn.Module):
         self.cache_batch_size = int(os.getenv("AWQ_BATCH_SIZE", "1"))
         self.max_seq_len = max_seq_len
         self.attention_shapes = self._get_attention_shapes(attention_shapes, max_seq_len)
-        self._initialize_cache(dev)
+        self.cache_v = ( torch.zeros(self.attention_shapes["cache_v"]).to(dev).half() )
+        self.cache_k = ( torch.zeros(self.attention_shapes["cache_k"]).to(dev).half() )
 
         if use_alibi:
             alibi_slopes, alibi_bias = build_alibi_bias(self.n_heads, max_seq_len)
@@ -100,15 +101,6 @@ class QuantAttentionFused(nn.Module):
             self.rotary_dim = self.head_dim
             self.alibi_slopes = None
             self.is_neox = True
-    
-    def _initialize_cache(self, dev):
-        self.cache_v = (
-            torch.zeros(self.attention_shapes["cache_v"]).to(dev).half()
-        )
-        
-        self.cache_k = (
-            torch.zeros(self.attention_shapes["cache_k"]).to(dev).half()
-        )
     
     def _get_attention_shapes(self, attention_shapes, max_seq_len):
         if attention_shapes is not None:

--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -1,11 +1,9 @@
 import os
 import math
 import torch
-import logging
 import torch.nn as nn
 import awq_inference_engine
 from torch.nn import functional as F
-from awq.utils.utils import compute_memory_used_pct
 
 try:
     import ft_inference_engine

--- a/awq/utils/utils.py
+++ b/awq/utils/utils.py
@@ -60,3 +60,8 @@ def clear_memory(weight=None):
         del weight
     gc.collect()
     torch.cuda.empty_cache()
+
+def compute_memory_used_pct(device):
+    memory_used = torch.cuda.max_memory_allocated(device) / (1024 ** 3)
+    memory_pct = memory_used / (torch.cuda.get_device_properties(device).total_memory / (1024 ** 3)) * 100
+    return memory_pct


### PR DESCRIPTION
Resolves #70 

- reset KV cache if it is exceeded
- reset and increase KV cache if the sequence length is larger than the max_new_tokens argument

`casperhansen/vicuna-7b-v1.5-awq`

Without fused modules:

|  Task  |Version|    Metric     | Value |   |Stderr|
|--------|------:|---------------|------:|---|------|
|wikitext|      1|word_perplexity|11.7194|   |      |
|        |       |byte_perplexity| 1.5845|   |      |
|        |       |bits_per_byte  | 0.6640|   |      |

With fused modules:

|  Task  |Version|    Metric     | Value |   |Stderr|
|--------|------:|---------------|------:|---|------|
|wikitext|      1|word_perplexity|11.7192|   |      |
|        |       |byte_perplexity| 1.5845|   |      |
|        |       |bits_per_byte  | 0.6640|   |      |
