### PR TITLE
Offloading to cpu and disk

### DIFF
--- a/awq/models/auto.py
+++ b/awq/models/auto.py
@@ -40,11 +40,13 @@ class AutoAWQForCausalLM:
     @classmethod
     def from_quantized(self, quant_path, quant_filename='', max_new_tokens=None,
                        trust_remote_code=True, fuse_layers=True,
-                       batch_size=1, safetensors=False) -> BaseAWQForCausalLM:
+                       batch_size=1, safetensors=False,
+                       max_memory=None, offload_folder=None) -> BaseAWQForCausalLM:
         os.environ["AWQ_BATCH_SIZE"] = str(batch_size)
         model_type = check_and_get_model_type(quant_path, trust_remote_code)
 
         return AWQ_CAUSAL_LM_MODEL_MAP[model_type].from_quantized(
             quant_path, model_type, quant_filename, max_new_tokens, trust_remote_code=trust_remote_code, 
-            fuse_layers=fuse_layers, safetensors=safetensors
+            fuse_layers=fuse_layers, safetensors=safetensors, 
+            max_memory=max_memory, offload_folder=offload_folder
         )

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -168,23 +168,16 @@ class BaseAWQForCausalLM(nn.Module):
         )
         
         # Dispath to devices
-        if max_memory is None:
-            # VRAM only
-            model = simple_dispatch_model(model, device_map)
+        if fuse_layers:
+            self.fuse_layers(model, quant_config)
 
-            if fuse_layers:
-                self.fuse_layers(model, quant_config)
-        else:
-            if fuse_layers:
-                self.fuse_layers(model, quant_config)
-
-            # Offloading dispatch
-            from accelerate import dispatch_model
-            model = dispatch_model(
-                model,
-                device_map=device_map,
-                offload_dir=offload_folder
-            )
+        # Offloading dispatch
+        from accelerate import dispatch_model
+        model = dispatch_model(
+            model,
+            device_map=device_map,
+            offload_dir=offload_folder
+        )
         
 
         return self(model, model_type, is_quantized=is_quantized, quant_config=quant_config)

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -156,7 +156,7 @@ class BaseAWQForCausalLM(nn.Module):
             no_split_module_classes=[self.layer_type], 
             max_memory=max_memory,
             dtype=torch_dtype
-            )
+        )
 
         # Load checkpoint
         load_checkpoint_in_model(
@@ -183,7 +183,6 @@ class BaseAWQForCausalLM(nn.Module):
             model = dispatch_model(
                 model,
                 device_map=device_map,
-                # offload_buffers=offload_folder is not None,
                 offload_dir=offload_folder
             )
         

--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -36,7 +36,7 @@ def apply_rotary_emb(
     xk_ = torch.view_as_complex(
         xk.float().reshape(*xk.shape[:-1], 2, -1).transpose(-2, -1).contiguous()
     )
-    freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
+    freqs_cis = reshape_for_broadcast(freqs_cis, xq_).to(xq_.device)
     xq_out = torch.view_as_real(xq_ * freqs_cis).transpose(-2, -1).flatten(3)
     xk_out = torch.view_as_real(xk_ * freqs_cis).transpose(-2, -1).flatten(3)
     return xq_out.type_as(xq), xk_out.type_as(xk)


### PR DESCRIPTION
Greetings.

This PR adds arguments `max_memory` and `offload_folder` to the `from_quantized()` method.

Additionally, for the offloading it relies on standard `accelerate.dispatch_model()` instead of `simple_dispatch()` and makes patches to the fusion layers before the offloading to prevent the cases where different tensors end up on different devices. Especially llama normalization layer stuck on `meta` device.

The code was tested on RTX3060 with this model - https://huggingface.co/TheBloke/Llama-2-70B-chat-AWQ

P.S. I've noticed a strange behavior with the `accelerate.infer_auto_device_map()`. Returned device map marks more layers to be placed in VRAM then it's physically possible. I haven't seen this with GPTQ models. Also not tested with the official AWQ implementation. Maybe authors of this repo have some ideas.