### PR TITLE
Fix unexpected keyword

### DIFF
--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -146,7 +146,8 @@ class QuantAttentionFused(nn.Module):
     
     def forward(
         self,
-        hidden_states:torch.Tensor, past_key_value=None, attention_mask=None, position_ids=None, output_attentions=False, use_cache=False
+        hidden_states:torch.Tensor, past_key_value=None, attention_mask=None, position_ids=None, 
+        output_attentions=False, use_cache=False, *args, **kwargs
     ):
         bsz, seqlen, _ = hidden_states.shape
         if bsz != self.cache_batch_size:


### PR DESCRIPTION
Fixes #86. https://github.com/huggingface/transformers/pull/25598 breaks AutoAWQ fused attention modules. This PR fixes it by accepting all args and kwargs.