### PR TITLE
SmoothQuant implementation

### DIFF
--- a/awq/models/llama.py
+++ b/awq/models/llama.py
@@ -5,7 +5,8 @@ from transformers.models.llama.modeling_llama import LlamaDecoderLayer, LlamaFor
 class LlamaAWQForCausalLM(BaseAWQForCausalLM):
     layer_type = "LlamaDecoderLayer"
     max_new_tokens_key = "max_position_embeddings"
-    quantize_output = ["q_proj", "k_proj", "v_proj"]
+    fp32_in = ["self_attn.q_proj", "mlp.gate_proj"]
+    fp32_out = ["self_attn.o_proj", "mlp.down_proj"]
 
     @staticmethod
     def fuse_layers(model: LlamaForCausalLM, quant_config: Dict):

--- a/awq/models/llama.py
+++ b/awq/models/llama.py
@@ -5,8 +5,7 @@ from transformers.models.llama.modeling_llama import LlamaDecoderLayer, LlamaFor
 class LlamaAWQForCausalLM(BaseAWQForCausalLM):
     layer_type = "LlamaDecoderLayer"
     max_new_tokens_key = "max_position_embeddings"
-    fp32_in = ["self_attn.q_proj", "mlp.gate_proj"]
-    fp32_out = ["self_attn.o_proj", "mlp.down_proj"]
+    fp32_out = ["self_attn.v_proj", "self_attn.o_proj", "mlp.gate_proj", "mlp.down_proj"]
 
     @staticmethod
     def fuse_layers(model: LlamaForCausalLM, quant_config: Dict):

--- a/awq/models/llama.py
+++ b/awq/models/llama.py
@@ -5,6 +5,7 @@ from transformers.models.llama.modeling_llama import LlamaDecoderLayer, LlamaFor
 class LlamaAWQForCausalLM(BaseAWQForCausalLM):
     layer_type = "LlamaDecoderLayer"
     max_new_tokens_key = "max_position_embeddings"
+    quantize_output = ["q_proj", "k_proj", "v_proj"]
 
     @staticmethod
     def fuse_layers(model: LlamaForCausalLM, quant_config: Dict):
@@ -37,6 +38,7 @@ class LlamaAWQForCausalLM(BaseAWQForCausalLM):
             layers=[module.self_attn.q_proj,
                     module.self_attn.k_proj, module.self_attn.v_proj],
             inp=input_feat['self_attn.q_proj'],
+            inp_name='self_attn.q_proj',
             module2inspect=module.self_attn, kwargs=module_kwargs,
         ))
 
@@ -47,6 +49,7 @@ class LlamaAWQForCausalLM(BaseAWQForCausalLM):
                 prev_op=module.self_attn.v_proj,
                 layers=[module.self_attn.o_proj],
                 inp=input_feat['self_attn.o_proj'],
+                inp_name='self_attn.o_proj',
             ))
         
         # linear 1
@@ -54,6 +57,7 @@ class LlamaAWQForCausalLM(BaseAWQForCausalLM):
             prev_op=module.post_attention_layernorm,
             layers=[module.mlp.gate_proj, module.mlp.up_proj],
             inp=input_feat['mlp.gate_proj'],
+            inp_name='mlp.gate_proj',
             module2inspect=module.mlp,
         ))
 
@@ -62,6 +66,7 @@ class LlamaAWQForCausalLM(BaseAWQForCausalLM):
             prev_op=module.mlp.up_proj,
             layers=[module.mlp.down_proj],
             inp=input_feat['mlp.down_proj'],
+            inp_name='mlp.down_proj',
         ))
 
         return layers

--- a/awq/modules/linear.py
+++ b/awq/modules/linear.py
@@ -210,70 +210,49 @@ class WQLinear_GEMV(nn.Module):
             self.in_features, self.out_features, self.bias is not None, self.w_bit, self.group_size
         )
 
-class WQLinear_W8A8(nn.Module):
-    def __init__(self, in_features, out_features, bias=True, act_quant='per_token', quantize_output=False):
+class WQLinear_FakeW8A8(nn.Module):
+    def __init__(self, in_features, out_features, act_quant='per_token', quantize_output=False, w_bit=8):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
+        self.w_bit = w_bit
 
         self.register_buffer('weight', torch.randn(
             self.out_features, self.in_features, dtype=torch.float16, requires_grad=False)
         )
-        if bias:
-            self.register_buffer('bias', torch.zeros(
-                (1, self.out_features), dtype=torch.float16, requires_grad=False)
-            )
-        else:
-            self.register_buffer('bias', None)
 
         if act_quant == 'per_token':
-            self.act_quant_name = 'per_token'
-            self.act_quant = partial(quantize_activation_per_token_absmax, n_bits=8)
-
+            self.quant_function = partial(quantize_activation_per_token_absmax, n_bits=self.w_bit)
         elif act_quant == 'per_tensor':
-            self.act_quant_name = 'per_tensor'
-            self.act_quant = partial(quantize_activation_per_tensor_absmax, n_bits=8)
+            self.quant_function = partial(quantize_activation_per_tensor_absmax, n_bits=self.w_bit)
 
         if quantize_output:
-            self.output_quant_name = self.act_quant_name
-            self.output_quant = self.act_quant
+            self.quant_output_function = self.quant_function
         else:
-            self.output_quant_name = 'None'
-            self.output_quant = lambda x: x
+            self.quant_output_function = lambda x: x
 
     def to(self, *args, **kwargs):
-        super(WQLinear_W8A8, self).to(*args, **kwargs)
+        super(WQLinear_FakeW8A8, self).to(*args, **kwargs)
         self.weight = self.weight.to(*args, **kwargs)
-        if self.bias is not None:
-            self.bias = self.bias.to(*args, **kwargs)
         return self
-
-    @torch.no_grad()
-    def forward(self, x):
-        q_x = self.act_quant(x)
-        y = torch.functional.F.linear(q_x, self.weight, self.bias)
-        q_y = self.output_quant(y)
-        return q_y
-
+    
     @staticmethod
-    def from_float(module, weight_quant='per_channel', act_quant='per_token', quantize_output=False):
-        assert isinstance(module, torch.nn.Linear)
-        new_module = WQLinear_W8A8(
-            module.in_features, module.out_features, module.bias is not None, 
-            act_quant=act_quant, quantize_output=quantize_output
+    def from_linear(module: nn.Linear, weight_quant='per_channel', act_quant='per_token', quantize_output=False, w_bit=8):
+        new_module = WQLinear_FakeW8A8(
+            module.in_features, module.out_features, act_quant=act_quant,
+            quantize_output=quantize_output, w_bit=w_bit
         )
         
         if weight_quant == 'per_channel':
             new_module.weight = quantize_weight_per_channel_absmax(module.weight, n_bits=8)
         elif weight_quant == 'per_tensor':
             new_module.weight = quantize_weight_per_tensor_absmax(module.weight, n_bits=8)
-
-        new_module.weight_quant_name = weight_quant
-
-        if module.bias is not None:
-            new_module.bias = module.bias
         
         return new_module
 
-    def __repr__(self):
-        return f'W8A8Linear({self.in_features}, {self.out_features}, bias={self.bias is not None}, weight_quant={self.weight_quant_name}, act_quant={self.act_quant_name}, output_quant={self.output_quant_name})'
+    @torch.no_grad()
+    def forward(self, x):
+        x_quantized = self.quant_function(x)
+        output = torch.functional.F.linear(x_quantized, self.weight)
+        output_quantized = self.quant_output_function(output)
+        return output_quantized

--- a/awq/modules/linear.py
+++ b/awq/modules/linear.py
@@ -1,8 +1,9 @@
 import math
 import torch
 import torch.nn as nn
-import awq_inference_engine  # with CUDA kernels
-
+import awq_inference_engine
+from functools import partial
+from awq.quantize.apply_quant import *
 
 def make_divisible(c, divisor):
     return (c + divisor - 1) // divisor
@@ -208,3 +209,71 @@ class WQLinear_GEMV(nn.Module):
         return 'in_features={}, out_features={}, bias={}, w_bit={}, group_size={}'.format(
             self.in_features, self.out_features, self.bias is not None, self.w_bit, self.group_size
         )
+
+class WQLinear_W8A8(nn.Module):
+    def __init__(self, in_features, out_features, bias=True, act_quant='per_token', quantize_output=False):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.register_buffer('weight', torch.randn(
+            self.out_features, self.in_features, dtype=torch.float16, requires_grad=False)
+        )
+        if bias:
+            self.register_buffer('bias', torch.zeros(
+                (1, self.out_features), dtype=torch.float16, requires_grad=False)
+            )
+        else:
+            self.register_buffer('bias', None)
+
+        if act_quant == 'per_token':
+            self.act_quant_name = 'per_token'
+            self.act_quant = partial(quantize_activation_per_token_absmax, n_bits=8)
+
+        elif act_quant == 'per_tensor':
+            self.act_quant_name = 'per_tensor'
+            self.act_quant = partial(quantize_activation_per_tensor_absmax, n_bits=8)
+
+        if quantize_output:
+            self.output_quant_name = self.act_quant_name
+            self.output_quant = self.act_quant
+        else:
+            self.output_quant_name = 'None'
+            self.output_quant = lambda x: x
+
+    def to(self, *args, **kwargs):
+        super(WQLinear_W8A8, self).to(*args, **kwargs)
+        self.weight = self.weight.to(*args, **kwargs)
+        if self.bias is not None:
+            self.bias = self.bias.to(*args, **kwargs)
+        return self
+
+    @torch.no_grad()
+    def forward(self, x):
+        q_x = self.act_quant(x)
+        y = torch.functional.F.linear(q_x, self.weight, self.bias)
+        q_y = self.output_quant(y)
+        return q_y
+
+    @staticmethod
+    def from_float(module, weight_quant='per_channel', act_quant='per_token', quantize_output=False):
+        assert isinstance(module, torch.nn.Linear)
+        new_module = WQLinear_W8A8(
+            module.in_features, module.out_features, module.bias is not None, 
+            act_quant=act_quant, quantize_output=quantize_output
+        )
+        
+        if weight_quant == 'per_channel':
+            new_module.weight = quantize_weight_per_channel_absmax(module.weight, n_bits=8)
+        elif weight_quant == 'per_tensor':
+            new_module.weight = quantize_weight_per_tensor_absmax(module.weight, n_bits=8)
+
+        new_module.weight_quant_name = weight_quant
+
+        if module.bias is not None:
+            new_module.bias = module.bias
+        
+        return new_module
+
+    def __repr__(self):
+        return f'W8A8Linear({self.in_features}, {self.out_features}, bias={self.bias is not None}, weight_quant={self.weight_quant_name}, act_quant={self.act_quant_name}, output_quant={self.output_quant_name})'

--- a/awq/modules/linear.py
+++ b/awq/modules/linear.py
@@ -276,7 +276,8 @@ class WQLinear_W8A8(nn.Module):
         self.register_buffer('beta', torch.tensor(beta))
     
     @staticmethod
-    def from_linear(module: nn.Linear, weight_quant, output_scale=None, fp32_in=None, fp32_out=False, alpha=1.0, init_only=False):
+    def from_linear(module: nn.Linear, weight_quant, input_scale=None, output_scale=None, 
+                    fp32_in=None, fp32_out=False, alpha=1.0, init_only=False):
         # fp32_in is layers like q_proj and gate_proj (first layer)
         # fp32_out is layers like o_proj and down_proj (last layer)
         linear = WQLinear_W8A8(
@@ -301,10 +302,10 @@ class WQLinear_W8A8(nn.Module):
         bias = torch.zeros((1, linear.out_features), dtype=torch.float32, requires_grad=False)
         if fp32_out:
             linear.bias = bias
-            linear.alpha = alpha * weight_scales
+            linear.alpha = input_scale * weight_scales
         else:
             linear.bias, bias_scales = quant_function(bias, n_bits=8, get_scale=True)
-            linear.alpha = alpha * weight_scales / output_scale
+            linear.alpha = input_scale * weight_scales / output_scale
             linear.beta = bias_scales / output_scale
 
         return linear

--- a/awq/quantize/apply_quant.py
+++ b/awq/quantize/apply_quant.py
@@ -1,39 +1,55 @@
 import torch
 
 @torch.no_grad()
-def quantize_weight_per_channel_absmax(w, n_bits=8):
+def quantize_weight_per_channel_absmax(w, n_bits=8, get_scale=False):
     # w: (out_features, in_features)
     scales = w.abs().max(dim=-1, keepdim=True)[0]
     q_max = 2**(n_bits-1)-1
     scales.clamp_(min=1e-5).div_(q_max)
     w.div_(scales).round_().mul_(scales)
-    return w
+
+    if get_scale:
+        return w, scales
+    else:
+        return w
 
 @torch.no_grad()
-def quantize_weight_per_tensor_absmax(w, n_bits=8):
+def quantize_weight_per_tensor_absmax(w, n_bits=8, get_scale=False):
     # w: (out_features, in_features)
     scales = w.abs().max()
     q_max = 2**(n_bits-1)-1
     scales.clamp_(min=1e-5).div_(q_max)
     w.div_(scales).round_().mul_(scales)
-    return w
+
+    if get_scale:
+        return w, scales
+    else:
+        return w
 
 @torch.no_grad()
-def quantize_activation_per_token_absmax(t, n_bits=8):
+def quantize_activation_per_token_absmax(t, n_bits=8, get_scale=False):
     t_shape = t.shape
     t.view(-1, t_shape[-1])
     scales = t.abs().max(dim=-1, keepdim=True)[0]
     q_max = 2**(n_bits-1)-1
     scales.clamp_(min=1e-5).div_(q_max)
     t.div_(scales).round_().mul_(scales)
-    return t
+
+    if get_scale:
+        return t, scales
+    else:
+        return t
 
 @torch.no_grad()
-def quantize_activation_per_tensor_absmax(t, n_bits=8):
+def quantize_activation_per_tensor_absmax(t, n_bits=8, get_scale=False):
     t_shape = t.shape
     t.view(-1, t_shape[-1])
     scales = t.abs().max()
     q_max = 2**(n_bits-1)-1
     scales.clamp_(min=1e-5).div_(q_max)
     t.div_(scales).round_().mul_(scales)
-    return t
+
+    if get_scale:
+        return t, scales
+    else:
+        return t

--- a/awq/quantize/apply_quant.py
+++ b/awq/quantize/apply_quant.py
@@ -1,0 +1,39 @@
+import torch
+
+@torch.no_grad()
+def quantize_weight_per_channel_absmax(w, n_bits=8):
+    # w: (out_features, in_features)
+    scales = w.abs().max(dim=-1, keepdim=True)[0]
+    q_max = 2**(n_bits-1)-1
+    scales.clamp_(min=1e-5).div_(q_max)
+    w.div_(scales).round_().mul_(scales)
+    return w
+
+@torch.no_grad()
+def quantize_weight_per_tensor_absmax(w, n_bits=8):
+    # w: (out_features, in_features)
+    scales = w.abs().max()
+    q_max = 2**(n_bits-1)-1
+    scales.clamp_(min=1e-5).div_(q_max)
+    w.div_(scales).round_().mul_(scales)
+    return w
+
+@torch.no_grad()
+def quantize_activation_per_token_absmax(t, n_bits=8):
+    t_shape = t.shape
+    t.view(-1, t_shape[-1])
+    scales = t.abs().max(dim=-1, keepdim=True)[0]
+    q_max = 2**(n_bits-1)-1
+    scales.clamp_(min=1e-5).div_(q_max)
+    t.div_(scales).round_().mul_(scales)
+    return t
+
+@torch.no_grad()
+def quantize_activation_per_tensor_absmax(t, n_bits=8):
+    t_shape = t.shape
+    t.view(-1, t_shape[-1])
+    scales = t.abs().max()
+    q_max = 2**(n_bits-1)-1
+    scales.clamp_(min=1e-5).div_(q_max)
+    t.div_(scales).round_().mul_(scales)
+    return t

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -387,7 +387,6 @@ class SmoothQuantizer:
     
     def apply_quantization(self, module, named_linears, static_scales, prev_op, layers: List[nn.Linear], inp: torch.Tensor, inp_name: str, module2inspect=None, kwargs={}):
         for name, linear_layer in named_linears.items():
-            fp32_in = name in self.awq_model.fp32_in
             fp32_out = name in self.awq_model.fp32_out
             full_name = f"{get_op_name(self.model, module)}.{inp_name}"
             
@@ -396,7 +395,6 @@ class SmoothQuantizer:
                 weight_quant=self.weight_quant,
                 input_scale=static_scales[full_name]["input"],
                 output_scale=static_scales[full_name]["output"],
-                fp32_in=fp32_in,
                 fp32_out=fp32_out,
                 alpha=self.alpha
             )

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from awq.utils.utils import clear_memory
 from awq.utils.calib_data import get_calib_dataset
 from awq.quantize.scale import apply_scale, apply_clip
-from awq.modules.linear import WQLinear_GEMM, WQLinear_GEMV, WQLinear_W8A8
+from awq.modules.linear import WQLinear_GEMM, WQLinear_GEMV, WQLinear_FakeW8A8
 from awq.quantize.scale import allowed_norms, scale_ln_fcs, scale_fc_fcs, extract_scales
 from awq.utils.module import append_str_prefix, get_op_name, get_named_linears, set_op_by_name
 
@@ -383,8 +383,9 @@ class SmoothQuantizer:
                 linear_layer = linear_layer.cuda()
 
                 quantize_output = name in self.awq_model.quantize_output
-                q_linear = WQLinear_W8A8.from_float(
-                    linear_layer, self.weight_quant, self.act_quant, quantize_output=quantize_output
+                q_linear = WQLinear_FakeW8A8.from_linear(
+                    linear_layer, self.weight_quant, self.act_quant, 
+                    quantize_output=quantize_output, w_bit=self.w_bit
                 )
 
                 linear_layer.cpu()

--- a/awq/quantize/scale.py
+++ b/awq/quantize/scale.py
@@ -75,10 +75,6 @@ def extract_scales(fcs: List[nn.Linear], act_scales, alpha):
     return scales
 
 @torch.no_grad()
-def scale_inputs(x, input_scale):
-    return (x / input_scale).round().clamp(-128, 127).to(torch.int8)
-
-@torch.no_grad()
 def scale_ln_fcs(ln: nn.Linear, fcs: List[nn.Linear], scales: torch.Tensor):
     if not isinstance(fcs, list):
         fcs = [fcs]

--- a/awq/quantize/scale.py
+++ b/awq/quantize/scale.py
@@ -75,6 +75,10 @@ def extract_scales(fcs: List[nn.Linear], act_scales, alpha):
     return scales
 
 @torch.no_grad()
+def scale_inputs(x, input_scale):
+    return (x / input_scale).round().clamp(-128, 127).to(torch.int8)
+
+@torch.no_grad()
 def scale_ln_fcs(ln: nn.Linear, fcs: List[nn.Linear], scales: torch.Tensor):
     if not isinstance(fcs, list):
         fcs = [fcs]

--- a/awq/utils/perplexity_utils.py
+++ b/awq/utils/perplexity_utils.py
@@ -1,0 +1,73 @@
+import torch
+import numpy as np
+from tqdm import tqdm
+from datasets import load_dataset
+
+class Perplexity:
+    def __init__(self, model, tokenizer, dataset_path='wikitext', dataset_name=None, split='test', text_column='text'):
+        self._model = model
+        self._tokenizer = tokenizer
+        self._dataset_path = dataset_path
+        self._dataset_name = dataset_name
+        self._split = split
+        self._text_column = text_column
+        self._text = self._prepare_data()
+        self._total_nll = 0.0
+        self._count = 0
+        self.max_length = 2048
+
+    def _get_device(self):
+        if torch.backends.mps.is_available():
+            return 'mps'
+        elif torch.cuda.is_available():
+            return 'cuda:0'
+        else:
+            return 'cpu'
+
+    def _prepare_data(self):
+        if self._dataset_path == 'wikitext':
+            self._dataset_name = 'wikitext-2-raw-v1'
+        
+        data = load_dataset(self._dataset_path, self._dataset_name, split=self._split)
+        text_list = [' \n' if s == '' else s for s in data[self._text_column]]
+        return ''.join(text_list)
+
+    def calculate_perplexity(self, stride=512, tokens=None, n_rounds=-1):
+        if tokens is None:
+            tokens = self._tokenizer(self._text, truncation=False, return_tensors="pt").input_ids.to(self._model.device)
+        
+        seq_len = tokens.size(1)
+        prev_end_loc = 0
+        all_perplexity = []
+
+        if n_rounds != -1:
+            full_range = [list(range(0, seq_len, stride))[:n_rounds]]
+        else:
+            full_range = range(0, seq_len, stride)
+
+        with tqdm(full_range, desc="Perplexity: - ") as progress:
+            for begin_loc in progress:
+                nll = self._process_batch(tokens, begin_loc, prev_end_loc)
+                self._total_nll += nll.item()
+                self._count += 1
+                prev_end_loc = min(begin_loc + self.max_length, seq_len)
+
+                # Compute the running perplexity and update the tqdm description
+                running_perplexity = np.exp(self._total_nll / self._count)
+                all_perplexity.append(running_perplexity)
+                progress.set_description(f"Perplexity: {running_perplexity:.4f}")
+
+        return all_perplexity
+
+    def _process_batch(self, tokens, begin_loc, prev_end_loc):
+        end_loc = min(begin_loc + self.max_length, tokens.size(1))
+        trg_len = end_loc - prev_end_loc  # may be different from stride on last loop
+        input_ids = tokens[:, begin_loc:end_loc].to(self._model.device)
+        target_ids = input_ids.clone()
+        target_ids[:, :-trg_len] = -100
+
+        with torch.no_grad():
+            outputs = self._model(input_ids, labels=target_ids)
+            neg_log_likelihood = outputs.loss
+
+        return neg_log_likelihood

--- a/awq_cuda/gemm/bmm.cu
+++ b/awq_cuda/gemm/bmm.cu
@@ -1,0 +1,211 @@
+#include "include/bmm.h"
+#include "include/common.h"
+#include <cutlass/core_io.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/gemm/device/gemm.h>
+#include <cutlass/gemm/device/gemm_batched.h>
+#include <cutlass/numeric_types.h>
+#include <cutlass/util/host_tensor.h>
+
+torch::Tensor bmm_s8t_s8n_f32t(torch::Tensor A, torch::Tensor B, float alpha) {
+  int batch_size = A.size(0);
+  int M = A.size(1);
+  int N = B.size(1);
+  int K = A.size(2);
+
+  auto C = torch::empty({batch_size, M, N},
+                        torch::dtype(torch::kFloat32).device(A.device()));
+  int lda = A.size(2);
+  int ldb = B.size(2);
+  int ldc = C.size(2);
+
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using ElementOutput = float;
+  using ElementInputA = int8_t;
+  using ElementInputB = int8_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+      ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+      ElementAccumulator, ElementComputeEpilogue>;
+
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm80, cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      EpilogueOp>;
+
+  long long int batch_stride_A = M * K;
+  long long int batch_stride_B = N * K;
+  long long int batch_stride_C = M * N;
+
+  Gemm gemm_op;
+  typename Gemm::Arguments arguments{
+      {M, N, K},      {A.data_ptr<ElementInputA>(), lda},
+      batch_stride_A, {B.data_ptr<ElementInputB>(), ldb},
+      batch_stride_B, {C.data_ptr<ElementOutput>(), ldc},
+      batch_stride_C, {C.data_ptr<ElementOutput>(), ldc},
+      batch_stride_C, {alpha, 0},
+      batch_size};
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run");
+  }
+  return C;
+}
+
+torch::Tensor bmm_s8t_s8n_s8t(torch::Tensor A, torch::Tensor B, float alpha) {
+  int batch_size = A.size(0);
+  int M = A.size(1);
+  int N = B.size(1);
+  int K = A.size(2);
+
+  auto C = torch::empty({batch_size, M, N},
+                        torch::dtype(torch::kInt8).device(A.device()));
+  int lda = A.size(2);
+  int ldb = B.size(2);
+  int ldc = C.size(2);
+
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using ElementOutput = int8_t;
+  using ElementInputA = int8_t;
+  using ElementInputB = int8_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationClamp<
+      ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+      ElementAccumulator, ElementComputeEpilogue>;
+
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm80, cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      EpilogueOp>;
+
+  long long int batch_stride_A = M * K;
+  long long int batch_stride_B = N * K;
+  long long int batch_stride_C = M * N;
+
+  Gemm gemm_op;
+  typename Gemm::Arguments arguments{
+      {M, N, K},      {A.data_ptr<ElementInputA>(), lda},
+      batch_stride_A, {B.data_ptr<ElementInputB>(), ldb},
+      batch_stride_B, {C.data_ptr<ElementOutput>(), ldc},
+      batch_stride_C, {C.data_ptr<ElementOutput>(), ldc},
+      batch_stride_C, {alpha, 0},
+      batch_size};
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run");
+  }
+  return C;
+}
+
+torch::Tensor bmm_s8t_s8n_s32t(torch::Tensor A, torch::Tensor B) {
+  int batch_size = A.size(0);
+  int M = A.size(1);
+  int N = B.size(1);
+  int K = A.size(2);
+
+  auto C = torch::empty({batch_size, M, N},
+                        torch::dtype(torch::kInt32).device(A.device()));
+  int lda = A.size(2);
+  int ldb = B.size(2);
+  int ldc = C.size(2);
+
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using ElementOutput = int32_t;
+  using ElementInputA = int8_t;
+  using ElementInputB = int8_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = int32_t;
+
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+      ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+      ElementAccumulator, ElementComputeEpilogue>;
+
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm80, cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      EpilogueOp>;
+
+  long long int batch_stride_A = M * K;
+  long long int batch_stride_B = N * K;
+  long long int batch_stride_C = M * N;
+
+  Gemm gemm_op;
+
+  ElementComputeEpilogue alpha = 1;
+
+  cutlass::Status status = gemm_op({{M, N, K},
+                                    {A.data_ptr<ElementInputA>(), lda},
+                                    batch_stride_A,
+                                    {B.data_ptr<ElementInputB>(), ldb},
+                                    batch_stride_B,
+                                    {C.data_ptr<ElementOutput>(), ldc},
+                                    batch_stride_C,
+                                    {C.data_ptr<ElementOutput>(), ldc},
+                                    batch_stride_C,
+                                    {alpha, 0},
+                                    batch_size});
+
+  if (status != cutlass::Status::kSuccess) {
+    std::cout << "cutlass error code: " << (int)status << std::endl;
+  }
+  return C;
+}

--- a/awq_cuda/gemm/fused.cu
+++ b/awq_cuda/gemm/fused.cu
@@ -1,0 +1,25 @@
+#include "include/fused.h"
+#include "include/common.h"
+
+
+std::tuple<torch::Tensor,
+           torch::Tensor> // (residual_output (FP), ln_output (INT8))
+dq_add_layernorm_q(
+    torch::Tensor input,          // INT32
+    float input_scale,            // FP
+    torch::Tensor residual_input, // FP
+    torch::Tensor gamma,          // FP
+    torch::Tensor beta,           // FP
+    float epsilon                 // FP
+    ) // The output scale has already been fused into gamma and beta
+{
+  // residual_output = residual_input + input * input_scale
+  auto residual_output_fp = torch::add(residual_input, input, input_scale);
+
+  auto ln_output_fp =
+      torch::layer_norm(residual_output_fp, {residual_output_fp.size(-1)},
+                        gamma, beta, epsilon);
+  ln_output_fp.clamp_(-128, 127).round_();
+  auto ln_output_int8 = ln_output_fp.to(torch::kChar);
+  return std::make_tuple(residual_output_fp, ln_output_int8);
+}

--- a/awq_cuda/gemm/include/bmm.h
+++ b/awq_cuda/gemm/include/bmm.h
@@ -1,0 +1,10 @@
+#ifndef BMM_H
+#define BMM_H
+#include <torch/types.h>
+torch::Tensor bmm_s8t_s8n_f32t(torch::Tensor A, torch::Tensor B, float alpha);
+
+torch::Tensor bmm_s8t_s8n_s8t(torch::Tensor A, torch::Tensor B, float alpha);
+
+torch::Tensor bmm_s8t_s8n_s32t(torch::Tensor A, torch::Tensor B);
+
+#endif // BMM_H

--- a/awq_cuda/gemm/include/common.h
+++ b/awq_cuda/gemm/include/common.h
@@ -1,0 +1,11 @@
+#ifndef COMMON_H
+#define COMMON_H
+#include <cstdint>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <iostream>
+#include <torch/torch.h>
+
+
+#endif // !COMMON

--- a/awq_cuda/gemm/include/fused.h
+++ b/awq_cuda/gemm/include/fused.h
@@ -1,0 +1,16 @@
+#ifndef FUSED_H
+#define FUSED_H
+
+#include <torch/types.h>
+
+std::tuple<torch::Tensor,
+           torch::Tensor> // (residual_output (FP), ln_output (INT8))
+dq_add_layernorm_q(torch::Tensor input,          // INT32
+                   float input_scale,            // FP
+                   torch::Tensor residual_input, // FP
+                   torch::Tensor gamma,          // FP
+                   torch::Tensor beta,           // FP
+                   float epsilon                 // FP
+); // The output scale has already been fused into gamma and beta
+
+#endif // FUSED_H

--- a/awq_cuda/gemm/include/linear.h
+++ b/awq_cuda/gemm/include/linear.h
@@ -1,0 +1,43 @@
+#ifndef LINEAR_H
+#define LINEAR_H
+#include <torch/types.h>
+
+// used by out_proj and fc2, return INT32
+torch::Tensor linear_a8_w8_b32_o32(torch::Tensor input,  // INT8
+                                   torch::Tensor weight, // INT8
+                                   torch::Tensor bias    // INT32
+);
+
+// used by out_proj and fc2, return INT32
+torch::Tensor linear_a8_w8_b32_o32_with_scaling(torch::Tensor input,  // INT8
+                                                torch::Tensor weight, // INT8
+                                                torch::Tensor bias,   // INT32
+                                                float alpha,          // FP32
+                                                float beta            // FP32
+);
+
+// used by out_proj and fc2, return FP32
+torch::Tensor linear_a8_w8_bfp32_ofp32(torch::Tensor input,  // INT8
+                                       torch::Tensor weight, // INT8
+                                       torch::Tensor bias,   // FP32
+                                       float alpha,          // FP32
+                                       float beta            // FP32
+);
+
+// used by fc1, return INT8
+torch::Tensor linear_relu_a8_w8_b8_o8(torch::Tensor input,  // INT8
+                                      torch::Tensor weight, // INT8
+                                      torch::Tensor bias,   // INT8
+                                      float alpha,          // FP32
+                                      float beta            // FP32
+);
+
+// used by q_proj, k_proj, v_proj, return INT8
+torch::Tensor linear_a8_w8_b8_o8(torch::Tensor input,  // INT8
+                                 torch::Tensor weight, // INT8
+                                 torch::Tensor bias,   // INT8
+                                 float alpha,          // FP32
+                                 float beta            // FP32
+);
+
+#endif // LINEAR_HS

--- a/awq_cuda/gemm/linear.cu
+++ b/awq_cuda/gemm/linear.cu
@@ -1,0 +1,491 @@
+#include "include/linear.h"
+#include "include/common.h"
+
+#include <cutlass/core_io.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/half.h>
+
+#include <cutlass/gemm/device/gemm.h>
+#include <cutlass/numeric_types.h>
+#include <cutlass/util/host_tensor.h>
+
+// used by out_proj and fc2, return INT32
+torch::Tensor linear_a8_w8_b32_o32(torch::Tensor input,  // INT8
+                                   torch::Tensor weight, // INT8
+                                   torch::Tensor bias    // INT32
+) {
+  auto M = input.size(0);
+  auto N = weight.size(0);
+  auto K = input.size(1);
+
+  using ElementOutput = int32_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = int32_t;
+  using ElementInputA = int8_t; // <- data type of elements in input matrix A
+  using ElementInputB = int8_t; // <- data type of elements in input matrix B
+
+  // The code section below describes matrix layout of input and output
+  // matrices. Column Major for Matrix A, Row Major for Matrix B and Row Major
+  // for Matrix C
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      cutlass::epilogue::thread::LinearCombination<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+          ElementAccumulator, ElementComputeEpilogue,
+          cutlass::epilogue::thread::ScaleType::NoBetaScaling>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+
+  auto input_size = cutlass::MatrixCoord(M, K);
+  auto weight_size = cutlass::MatrixCoord(K, N);
+  auto output_size = cutlass::MatrixCoord(M, N);
+
+  auto device = input.device();
+  // use the broadcasted bias as the output
+  auto out = bias.to(device).view({1, -1}).repeat({M, 1});
+
+  // constexpr int kSparse = Gemm::kSparse;
+  // How many elements of A are covered per ElementE
+  // constexpr int kElementsPerElementE = Gemm::kElementsPerElementE;
+  // The size of individual meta data
+  // constexpr int kMetaSizeInBits = Gemm::kMetaSizeInBits;
+  cutlass::gemm::GemmCoord problem_size(M, N, K);
+
+  cutlass::TensorRef<ElementInputA, LayoutInputA> input_ref(
+      input.data_ptr<int8_t>(), LayoutInputA::packed(input_size));
+  cutlass::TensorRef<ElementInputB, LayoutInputB> weight_ref(
+      weight.data_ptr<int8_t>(), LayoutInputB::packed(weight_size));
+  cutlass::TensorRef<ElementOutput, LayoutOutput> out_ref(
+      out.data_ptr<int32_t>(), LayoutOutput::packed(output_size));
+
+  // Initialize alpha and beta for dot product computation
+  ElementComputeEpilogue alpha = ElementComputeEpilogue(1);
+
+  typename Gemm::Arguments arguments{
+      problem_size, // <- problem size of matrix multiplication
+      input_ref,    // <- reference to matrix A on device
+      weight_ref,   // <- reference to matrix B on device
+      out_ref,      // <- reference to matrix C on device
+      out_ref,      // <- reference to matrix D on device
+      {alpha},      1};
+  Gemm gemm_op;
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run");
+  }
+
+  return out;
+}
+
+// used by out_proj and fc2, return INT32
+torch::Tensor linear_a8_w8_b32_o32_with_scaling(torch::Tensor input,  // INT8
+                                                torch::Tensor weight, // INT8
+                                                torch::Tensor bias,   // INT32
+                                                float alpha,          // FP32
+                                                float beta            // FP32
+) {
+  auto M = input.size(0);
+  auto N = weight.size(0);
+  auto K = input.size(1);
+
+  using ElementOutput = int32_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+  using ElementInputA = int8_t; // <- data type of elements in input matrix A
+  using ElementInputB = int8_t; // <- data type of elements in input matrix B
+
+  // The code section below describes matrix layout of input and output
+  // matrices. Column Major for Matrix A, Row Major for Matrix B and Row Major
+  // for Matrix C
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      cutlass::epilogue::thread::LinearCombination<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+          ElementAccumulator, ElementComputeEpilogue>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+
+  auto input_size = cutlass::MatrixCoord(M, K);
+  auto weight_size = cutlass::MatrixCoord(K, N);
+  auto output_size = cutlass::MatrixCoord(M, N);
+
+  auto device = input.device();
+  // use the broadcasted bias as the output
+  auto out = bias.to(device).view({1, -1}).repeat({M, 1});
+
+  // constexpr int kSparse = Gemm::kSparse;
+  // How many elements of A are covered per ElementE
+  // constexpr int kElementsPerElementE = Gemm::kElementsPerElementE;
+  // The size of individual meta data
+  // constexpr int kMetaSizeInBits = Gemm::kMetaSizeInBits;
+  cutlass::gemm::GemmCoord problem_size(M, N, K);
+
+  cutlass::TensorRef<ElementInputA, LayoutInputA> input_ref(
+      input.data_ptr<int8_t>(), LayoutInputA::packed(input_size));
+  cutlass::TensorRef<ElementInputB, LayoutInputB> weight_ref(
+      weight.data_ptr<int8_t>(), LayoutInputB::packed(weight_size));
+  cutlass::TensorRef<ElementOutput, LayoutOutput> out_ref(
+      out.data_ptr<int32_t>(), LayoutOutput::packed(output_size));
+
+  typename Gemm::Arguments arguments{
+      problem_size, // <- problem size of matrix multiplication
+      input_ref,    // <- reference to matrix A on device
+      weight_ref,   // <- reference to matrix B on device
+      out_ref,      // <- reference to matrix C on device
+      out_ref,      // <- reference to matrix D on device
+      {alpha, beta}, 1};
+  Gemm gemm_op;
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run");
+  }
+
+  return out;
+}
+
+// used by out_proj and fc2, return FP32
+torch::Tensor linear_a8_w8_bfp32_ofp32(torch::Tensor input,  // INT8
+                                       torch::Tensor weight, // INT8
+                                       torch::Tensor bias,   // FP32
+                                       float alpha,          // FP32
+                                       float beta            // FP32
+) {
+  auto M = input.size(0);
+  auto N = weight.size(0);
+  auto K = input.size(1);
+
+  using ElementOutput = float;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+  using ElementInputA = int8_t; // <- data type of elements in input matrix A
+  using ElementInputB = int8_t; // <- data type of elements in input matrix B
+
+  // The code section below describes matrix layout of input and output
+  // matrices. Column Major for Matrix A, Row Major for Matrix B and Row Major
+  // for Matrix C
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      cutlass::epilogue::thread::LinearCombination<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+          ElementAccumulator, ElementComputeEpilogue>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+
+  auto input_size = cutlass::MatrixCoord(M, K);
+  auto weight_size = cutlass::MatrixCoord(K, N);
+  auto output_size = cutlass::MatrixCoord(M, N);
+
+  auto device = input.device();
+  // use the broadcasted bias as the output
+  auto out = bias.to(device).view({1, -1}).repeat({M, 1});
+
+  // constexpr int kSparse = Gemm::kSparse;
+  // How many elements of A are covered per ElementE
+  // constexpr int kElementsPerElementE = Gemm::kElementsPerElementE;
+  // The size of individual meta data
+  // constexpr int kMetaSizeInBits = Gemm::kMetaSizeInBits;
+  cutlass::gemm::GemmCoord problem_size(M, N, K);
+
+  cutlass::TensorRef<ElementInputA, LayoutInputA> input_ref(
+      input.data_ptr<ElementInputA>(), LayoutInputA::packed(input_size));
+  cutlass::TensorRef<ElementInputB, LayoutInputB> weight_ref(
+      weight.data_ptr<ElementInputB>(), LayoutInputB::packed(weight_size));
+  cutlass::TensorRef<ElementOutput, LayoutOutput> out_ref(
+      out.data_ptr<ElementOutput>(), LayoutOutput::packed(output_size));
+
+  typename Gemm::Arguments arguments{
+      problem_size, // <- problem size of matrix multiplication
+      input_ref,    // <- reference to matrix A on device
+      weight_ref,   // <- reference to matrix B on device
+      out_ref,      // <- reference to matrix C on device
+      out_ref,      // <- reference to matrix D on device
+      {alpha, beta}, 1};
+  Gemm gemm_op;
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run");
+  }
+
+  return out;
+}
+
+
+// used by q_proj, k_proj, v_proj, return INT8
+torch::Tensor linear_a8_w8_b8_o8(torch::Tensor input,  // INT8
+                                 torch::Tensor weight, // INT8
+                                 torch::Tensor bias,   // INT8
+                                 float alpha,          // FP32
+                                 float beta            // FP32
+) {
+  auto M = input.size(0);
+  auto N = weight.size(0);
+  auto K = input.size(1);
+
+  using ElementOutput = int8_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+  using ElementInputA = int8_t; // <- data type of elements in input matrix A
+  using ElementInputB = int8_t; // <- data type of elements in input matrix B
+
+  // The code section below describes matrix layout of input and output
+  // matrices. Column Major for Matrix A, Row Major for Matrix B and Row Major
+  // for Matrix C
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      cutlass::epilogue::thread::FastLinearCombinationClamp<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+
+  auto input_size = cutlass::MatrixCoord(M, K);
+  auto weight_size = cutlass::MatrixCoord(K, N);
+  auto output_size = cutlass::MatrixCoord(M, N);
+  auto device = input.device();
+  auto out = bias.to(device).view({1, -1}).repeat({M, 1});
+
+  // constexpr int kSparse = Gemm::kSparse;
+  // How many elements of A are covered per ElementE
+  // constexpr int kElementsPerElementE = Gemm::kElementsPerElementE;
+  // The size of individual meta data
+  // constexpr int kMetaSizeInBits = Gemm::kMetaSizeInBits;
+  cutlass::gemm::GemmCoord problem_size(M, N, K);
+
+  cutlass::TensorRef<ElementInputA, LayoutInputA> input_ref(
+      input.data_ptr<int8_t>(), LayoutInputA::packed(input_size));
+  cutlass::TensorRef<ElementInputB, LayoutInputB> weight_ref(
+      weight.data_ptr<int8_t>(), LayoutInputB::packed(weight_size));
+  cutlass::TensorRef<ElementOutput, LayoutOutput> out_ref(
+      out.data_ptr<int8_t>(), LayoutOutput::packed(output_size));
+
+  typename Gemm::Arguments arguments{
+      problem_size, // <- problem size of matrix multiplication
+      input_ref,    // <- reference to matrix A on device
+      weight_ref,   // <- reference to matrix B on device
+      out_ref,      // <- reference to matrix C on device
+      out_ref,      // <- reference to matrix D on device
+      {alpha, beta}, 1};
+  Gemm gemm_op;
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement, status: " +
+                             std::to_string((int)status));
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize, status: " +
+                             std::to_string((int)status));
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run, status: " +
+                             std::to_string((int)status));
+  }
+
+  return out;
+}
+
+// used by fc1
+torch::Tensor linear_relu_a8_w8_b8_o8(torch::Tensor input,  // INT8
+                                      torch::Tensor weight, // INT8
+                                      torch::Tensor bias,   // INT8
+                                      float alpha,          // FP32
+                                      float beta            // FP32
+) {
+  auto M = input.size(0);
+  auto N = weight.size(0);
+  auto K = input.size(1);
+
+  using ElementOutput = int8_t;
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+  using ElementInputA = int8_t; // <- data type of elements in input matrix A
+  using ElementInputB = int8_t; // <- data type of elements in input matrix B
+
+  // The code section below describes matrix layout of input and output
+  // matrices. Column Major for Matrix A, Row Major for Matrix B and Row Major
+  // for Matrix C
+  using LayoutInputA = cutlass::layout::RowMajor;
+  using LayoutInputB = cutlass::layout::ColumnMajor;
+  using LayoutOutput = cutlass::layout::RowMajor;
+
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationRelu<
+      ElementOutput, // <- data type of output matrix
+      128 / cutlass::sizeof_bits<
+                ElementOutput>::value, // <- this is the number of elements per
+                                       // vectorized memory access. For half
+                                       // precision, it's 8 elements. This
+                                       // becomes the vector width of math
+                                       // instructions in epilogue too
+      ElementAccumulator,              // <- data type of accumulator
+      ElementComputeEpilogue // <- data type for alpha in linear combination
+                             // function
+      >;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
+      EpilogueOp, cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+      3>;
+
+  auto input_size = cutlass::MatrixCoord(M, K);
+  auto weight_size = cutlass::MatrixCoord(K, N);
+  auto output_size = cutlass::MatrixCoord(M, N);
+  auto device = input.device();
+  // use the broadcasted bias as the output
+  auto out = bias.to(device).view({1, -1}).repeat({M, 1});
+
+  // constexpr int kSparse = Gemm::kSparse;
+  // How many elements of A are covered per ElementE
+  // constexpr int kElementsPerElementE = Gemm::kElementsPerElementE;
+  // The size of individual meta data
+  // constexpr int kMetaSizeInBits = Gemm::kMetaSizeInBits;
+  cutlass::gemm::GemmCoord problem_size(M, N, K);
+
+  cutlass::TensorRef<ElementInputA, LayoutInputA> input_ref(
+      input.data_ptr<int8_t>(), LayoutInputA::packed(input_size));
+  cutlass::TensorRef<ElementInputB, LayoutInputB> weight_ref(
+      weight.data_ptr<int8_t>(), LayoutInputB::packed(weight_size));
+  cutlass::TensorRef<ElementOutput, LayoutOutput> out_ref(
+      out.data_ptr<int8_t>(), LayoutOutput::packed(output_size));
+
+  typename Gemm::Arguments arguments{
+      problem_size, // <- problem size of matrix multiplication
+      input_ref,    // <- reference to matrix A on device
+      weight_ref,   // <- reference to matrix B on device
+      out_ref,      // <- reference to matrix C on device
+      out_ref,      // <- reference to matrix D on device
+      {alpha, beta}, 1};
+  Gemm gemm_op;
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm_op.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement, status: " +
+                             std::to_string((int)status));
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm_op.initialize(arguments, workspace.get());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize, status: " +
+                             std::to_string((int)status));
+  }
+
+  status = gemm_op();
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot run, status: " +
+                             std::to_string((int)status));
+  }
+
+  return out;
+}

--- a/awq_cuda/pybind_int8.cpp
+++ b/awq_cuda/pybind_int8.cpp
@@ -1,0 +1,23 @@
+#include "gemm/include/bmm.h"
+#include "gemm/include/fused.h"
+#include "gemm/include/linear.h"
+#include <torch/extension.h>
+
+// A8 is the inputs running in INT8
+// W8 is the weights running in INT8
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("linear_relu_a8_w8_b8_o8", &linear_relu_a8_w8_b8_o8,
+        "Linear ReLU (INT8)");
+  m.def("linear_a8_w8_b32_o32", &linear_a8_w8_b32_o32, "Linear (INT32)");
+  m.def("linear_a8_w8_bfp32_ofp32", &linear_a8_w8_bfp32_ofp32,
+        "Linear (I8-OFP32)");
+  m.def("linear_a8_w8_b32_o32_with_scaling", &linear_a8_w8_b32_o32_with_scaling,
+        "Linear (INT32) with scaling");
+  m.def("linear_a8_w8_b8_o8", &linear_a8_w8_b8_o8, "Linear (INT8)");
+  m.def("dq_add_layernorm_q", &dq_add_layernorm_q,
+        "DQ + Add + LayerNorm (INT8)");
+  m.def("bmm_s8t_s8n_s8t", &bmm_s8t_s8n_s8t, "BMM (INT8 IO) A x B.T");
+  m.def("bmm_s8t_s8n_f32t", &bmm_s8t_s8n_f32t, "BMM (INT8 I FP32 O) A x B.T");
+  m.def("bmm_s8t_s8n_s32t", &bmm_s8t_s8n_s32t,
+        "BMM (INT8 In Int32 Out) A x B.T");
+}

--- a/examples/int8.py
+++ b/examples/int8.py
@@ -9,7 +9,5 @@ model = AutoAWQForCausalLM.from_pretrained(model_path, **{"low_cpu_mem_usage": T
 tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 model.quantize(tokenizer, quant_config=quant_config)
 
-model.model.cuda()
-
 ppl = Perplexity(model.model, tokenizer)
 out = ppl.calculate_perplexity()

--- a/examples/int8.py
+++ b/examples/int8.py
@@ -2,12 +2,24 @@ from awq import AutoAWQForCausalLM
 from transformers import AutoTokenizer
 from awq.utils.perplexity_utils import Perplexity
 
-model_path = 'PY007/TinyLlama-1.1B-intermediate-step-480k-1T'
+model_path = 'JackFram/llama-68m'
 quant_config = { "version": "SmoothQuant", "w_bit": 8 }
 
 model = AutoAWQForCausalLM.from_pretrained(model_path, **{"low_cpu_mem_usage": True})
 tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 model.quantize(tokenizer, quant_config=quant_config)
 
-ppl = Perplexity(model.model, tokenizer)
-out = ppl.calculate_perplexity()
+tokens = tokenizer(
+    "Hello",
+    return_tensors='pt'
+).input_ids.cuda()
+
+generation_output = model.generate(
+    tokens,
+    max_new_tokens=512
+)
+
+print(tokenizer.decode(generation_output[0]))
+
+# ppl = Perplexity(model.model, tokenizer)
+# out = ppl.calculate_perplexity()

--- a/examples/int8.py
+++ b/examples/int8.py
@@ -1,0 +1,15 @@
+from awq import AutoAWQForCausalLM
+from transformers import AutoTokenizer
+from awq.utils.perplexity_utils import Perplexity
+
+model_path = 'PY007/TinyLlama-1.1B-intermediate-step-480k-1T'
+quant_config = { "version": "SmoothQuant", "w_bit": 8 }
+
+model = AutoAWQForCausalLM.from_pretrained(model_path, **{"low_cpu_mem_usage": True})
+tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+model.quantize(tokenizer, quant_config=quant_config)
+
+model.model.cuda()
+
+ppl = Perplexity(model.model, tokenizer)
+out = ppl.calculate_perplexity()

--- a/scripts/install_cutlass.sh
+++ b/scripts/install_cutlass.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Download CUTLASS v2.11.0 (Not compatible with 3.x)
+git clone --depth 1 --branch v2.11.0 https://github.com/NVIDIA/cutlass.git
+cd cutlass
+rm -rf build
+mkdir -p build && cd build
+
+# Install CUTLASS
+export CUDACXX=/usr/local/cuda/bin/nvcc
+
+# NOTE: You can build for all Ampere+Hopper with 80;86;89;90
+cmake .. -DCUTLASS_NVCC_ARCHS="80" -DCUTLASS_ENABLE_TESTS=OFF -DCUTLASS_UNITY_BUILD_ENABLED=ON
+make -j $(nproc)
+
+# Copy over the files
+cp -r ../include/cutlass /usr/local/include/
+mkdir -p /usr/local/include/cutlass/util
+cp -r ../tools/util/include/cutlass/util/* /usr/local/include/cutlass/util/
+ldconfig
+rm -rf ../../cutlass

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,33 @@ extensions = [
             "awq_cuda/position_embedding/pos_encoding_kernels.cu",
             "awq_cuda/quantization/gemv_cuda.cu"
         ], extra_compile_args=extra_compile_args
+    ),
+    CUDAExtension(
+        "int8_engine",
+        [
+            "awq_cuda/pybind_int8.cpp",
+            'awq_cuda/gemm/linear.cu',
+            'awq_cuda/gemm/bmm.cu',
+            'awq_cuda/gemm/fused.cu',
+        ], 
+        include_dirs=[
+            'awq_cuda/gemm/include'
+        ],
+        extra_link_args=[
+            '-lcublas_static', '-lcublasLt_static',
+            '-lculibos', '-lcudart', '-lcudart_static',
+            '-lrt', '-lpthread', '-ldl', '-L/usr/lib/x86_64-linux-gnu/'
+        ],
+        extra_compile_args={
+            'cxx': ['-std=c++14', '-O3'],
+            'nvcc': [
+                '-O3', '-std=c++14',
+                '-U__CUDA_NO_HALF_OPERATORS__',
+                '-U__CUDA_NO_HALF_CONVERSIONS__',
+                '-U__CUDA_NO_HALF2_OPERATORS__',
+                f'-DCUDA_ARCH=80'
+            ]
+        }
     )
 ]
 


### PR DESCRIPTION
SmoothQuant quantizes inputs to models to INT8 and weights to INT8 such that we can use INT8 tensor cores to run native inference instead of dequantizing to FP16 to run inference.

### Perplexity

There are big issues with the SmoothQuant implementation is seems. Once we move from fake quant to static, the perplexity explodes. There may be some underlying issues.

Fake quant perplexity:

- Increase of 0.40% in perplexity
- TinyLlama FP16: 8.3974 perplexity
- TinyLlama INT8: 8.4314 perplexity

### TODO

- [x] Update method for collecting activation scales to [static hook](https://github.com/casper-hansen/smoothquant/blob/main/smoothquant/calibration.py#L135)
- [x] Initialize the real `WQLinear_W8A8`
    - [x] Needs `input_scale`, `output_scale`
    - [x] Set fp32_in and fp32_out  by defining them in model definition