### PR TITLE
[`core`] Support fp32 / bf16 inference

### DIFF
--- a/awq/modules/linear.py
+++ b/awq/modules/linear.py
@@ -97,7 +97,16 @@ class WQLinear_GEMM(nn.Module):
     @torch.no_grad()
     def forward(self, x):
         out_shape = x.shape[:-1] + (self.out_features, )
+
+        input_dtype = x.dtype
+        if input_dtype != torch.float16:
+            x = x.half()
+
         out = awq_inference_engine.gemm_forward_cuda(x.reshape(-1, x.shape[-1]), self.qweight, self.scales, self.qzeros, 8)
+        
+        if input_dtype != torch.float16:
+            out = out.to(dtype=input_dtype)
+        
         out = out + self.bias if self.bias is not None else out
         return out.reshape(out_shape)
     
@@ -195,11 +204,18 @@ class WQLinear_GEMV(nn.Module):
     def forward(self, x):
         out_shape = x.shape[:-1] + (self.out_features, )
         inputs = x.reshape(-1, x.shape[-1])
+
+        input_dtype = inputs.dtype
+        if input_dtype != torch.float16:
+            inputs = inputs.half()
         
         if inputs.shape[0] > 8:
             out = awq_inference_engine.gemmv2_forward_cuda(inputs, self.qweight, self.scales, self.qzeros, self.group_size, self.split_k_iters)
         else:
             out = awq_inference_engine.gemv_forward_cuda(inputs, self.qweight, self.scales, self.qzeros, self.group_size)
+
+        if input_dtype != torch.float16:
+            out = out.to(dtype=input_dtype)
         
         out = out + self.bias if self.bias is not None else out
         return out.reshape(out_shape)


### PR DESCRIPTION
# What does this PR do?

Some users might want to run inference with other modules being in `float32` or `bfloat16`. 
Using https://github.com/huggingface/transformers/pull/27045 one can easily simulate that scenario with the following script:

## For `float32`:

```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer

model_id = "ybelkada/test-mistral-7b-v0.1-awq"

tok = AutoTokenizer.from_pretrained(model_id)
model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float32).to(0)

print(model)

text = ["Hello my name is", "hi"]
input_ids = tok.encode(text, return_tensors="pt").to(0)

output = model.generate(input_ids, max_new_tokens=40)
print(tok.batch_decode(output, skip_special_tokens=True))
```

## For `bfloat16`:

```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer

model_id = "ybelkada/test-mistral-7b-v0.1-awq"

tok = AutoTokenizer.from_pretrained(model_id)
model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.bfloat16).to(0)

print(model)

text = ["Hello my name is", "hi"]
input_ids = tok.encode(text, return_tensors="pt").to(0)

output = model.generate(input_ids, max_new_tokens=40)
print(tok.batch_decode(output, skip_special_tokens=True))
```

cc @casper-hansen 