### PR TITLE
AwqConfig class

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The detailed support list:
 | ---------| ----------------------------|
 | LLaMA-2  | 7B/13B/70B                  |
 | LLaMA    | 7B/13B/30B/65B              |
+| Mistral  | 7B                          |
 | Vicuna   | 7B/13B                      |
 | MPT      | 7B/30B                      |
 | Falcon   | 7B/40B                      |
@@ -97,6 +98,8 @@ There are two versions of AWQ: GEMM and GEMV. Both names relate to how matrix mu
 
 ### Examples
 
+More examples can be found in the [examples directory](examples).
+
 <details>
 
 <summary>Quantization</summary>
@@ -109,7 +112,7 @@ from transformers import AutoTokenizer
 
 model_path = 'lmsys/vicuna-7b-v1.5'
 quant_path = 'vicuna-7b-v1.5-awq'
-quant_config = { "zero_point": True, "q_group_size": 128, "w_bit": 4 }
+quant_config = { "zero_point": True, "q_group_size": 128, "w_bit": 4, "version": "GEMM" }
 
 # Load model
 model = AutoAWQForCausalLM.from_pretrained(model_path)
@@ -134,10 +137,9 @@ from awq import AutoAWQForCausalLM
 from transformers import AutoTokenizer, TextStreamer
 
 quant_path = "casperhansen/vicuna-7b-v1.5-awq"
-quant_file = "awq_model_w4_g128.pt"
 
 # Load model
-model = AutoAWQForCausalLM.from_quantized(quant_path, quant_file, fuse_layers=True)
+model = AutoAWQForCausalLM.from_quantized(quant_path, fuse_layers=True)
 tokenizer = AutoTokenizer.from_pretrained(quant_path, trust_remote_code=True)
 streamer = TextStreamer(tokenizer, skip_special_tokens=True)
 

--- a/awq/models/_config.py
+++ b/awq/models/_config.py
@@ -1,7 +1,7 @@
 import os
 import json
 from typing import Dict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from transformers.utils.hub import PushToHubMixin, cached_file
 
 @dataclass
@@ -32,10 +32,9 @@ class AwqConfig(PushToHubMixin):
     @classmethod
     def from_dict(cls, quant_config: Dict={}):
         if not quant_config:
-            quant_config = cls.to_dict(cls)
-
-        if "version" not in quant_config.keys():
-            quant_config["version"] = cls.version
+            quant_config = cls()
+        else:
+            quant_config = cls(**quant_config)
         
         return quant_config
 
@@ -70,11 +69,12 @@ class AwqConfig(PushToHubMixin):
                 _commit_hash=commit_hash,
             )
         
-        with open(resolved_config_file, 'r', encoding="utf-8") as file:
-            quant_config = json.loads(file.read())
-
-        if "version" not in quant_config.keys():
-            quant_config["version"] = cls.version
+        if os.path.exists(resolved_config_file):
+            with open(resolved_config_file, 'r', encoding="utf-8") as file:
+                loaded_config = json.loads(file.read())
+                quant_config = cls(**loaded_config)
+        else:
+            quant_config = cls()
         
         return quant_config
 

--- a/awq/models/_config.py
+++ b/awq/models/_config.py
@@ -1,0 +1,96 @@
+import os
+import json
+from typing import Dict
+from dataclasses import dataclass, field
+from transformers.utils.hub import PushToHubMixin, cached_file
+
+@dataclass
+class AwqConfig(PushToHubMixin):
+    quant_method: str = field(default="awq")
+    zero_point: bool = field(default=True)
+    q_group_size: int = field(default=128)
+    w_bit: int = field(default=4)
+    version: str = field(default="GEMM")
+    config_file_name = "quant_config.json"
+
+    def save_pretrained(self, save_dir: str, **kwargs):
+        # quant_config.json
+        quant_config = self.to_dict()
+        with open(os.path.join(save_dir, self.config_file_name), "w+", encoding="utf-8") as file:
+            file.write(json.dumps(quant_config, indent=4))
+        
+        # config.json: quantization_config
+        config_filepath = os.path.join(save_dir, "config.json")
+        with open(config_filepath, 'r', encoding="utf-8") as file:
+            model_config = json.loads(file.read())
+        
+        model_config["quantization_config"] = self.to_transformers_dict()
+
+        with open(config_filepath, "w+", encoding="utf-8") as file:
+            file.write(json.dumps(model_config, indent=4))
+    
+    @classmethod
+    def from_dict(cls, quant_config: Dict={}):
+        if not quant_config:
+            quant_config = cls.to_dict(cls)
+
+        if "version" not in quant_config.keys():
+            quant_config["version"] = cls.version
+        
+        return quant_config
+
+    @classmethod
+    def from_pretrained(cls, save_dir: str, **kwargs):
+        cache_dir = kwargs.pop("cache_dir", None)
+        force_download = kwargs.pop("force_download", False)
+        resume_download = kwargs.pop("resume_download", False)
+        proxies = kwargs.pop("proxies", None)
+        local_files_only = kwargs.pop("local_files_only", False)
+        use_auth_token = kwargs.pop("use_auth_token", None)
+        revision = kwargs.pop("revision", None)
+        subfolder = kwargs.pop("subfolder", None)
+        commit_hash = kwargs.pop("_commit_hash", None)
+
+        if os.path.isdir(save_dir):  # Local
+            resolved_config_file = os.path.join(save_dir, cls.config_file_name)
+        else: # Remote
+            resolved_config_file = cached_file(
+                save_dir,
+                cls.config_file_name,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                resume_download=resume_download,
+                proxies=proxies,
+                use_auth_token=use_auth_token,
+                revision=revision,
+                local_files_only=local_files_only,
+                subfolder=subfolder,
+                _raise_exceptions_for_missing_entries=False,
+                _raise_exceptions_for_connection_errors=False,
+                _commit_hash=commit_hash,
+            )
+        
+        with open(resolved_config_file, 'r', encoding="utf-8") as file:
+            quant_config = json.loads(file.read())
+
+        if "version" not in quant_config.keys():
+            quant_config["version"] = cls.version
+        
+        return quant_config
+
+    def to_dict(self):
+        return {
+            "zero_point": self.zero_point,
+            "q_group_size": self.q_group_size,
+            "w_bit": self.w_bit,
+            "version": self.version
+        }
+
+    def to_transformers_dict(self):
+        return {
+            "quant_method": self.quant_method,
+            "zero_point": self.zero_point,
+            "group_size": self.q_group_size,
+            "bits": self.w_bit,
+            "version": self.version.lower(),
+        }

--- a/awq/models/_config.py
+++ b/awq/models/_config.py
@@ -14,20 +14,8 @@ class AwqConfig(PushToHubMixin):
     config_file_name = "quant_config.json"
 
     def save_pretrained(self, save_dir: str, **kwargs):
-        # quant_config.json
-        quant_config = self.to_dict()
         with open(os.path.join(save_dir, self.config_file_name), "w+", encoding="utf-8") as file:
-            file.write(json.dumps(quant_config, indent=4))
-        
-        # config.json: quantization_config
-        config_filepath = os.path.join(save_dir, "config.json")
-        with open(config_filepath, 'r', encoding="utf-8") as file:
-            model_config = json.loads(file.read())
-        
-        model_config["quantization_config"] = self.to_transformers_dict()
-
-        with open(config_filepath, "w+", encoding="utf-8") as file:
-            file.write(json.dumps(model_config, indent=4))
+            file.write(json.dumps(self.to_dict(), indent=4))
     
     @classmethod
     def from_dict(cls, quant_config: Dict={}):

--- a/awq/models/_config.py
+++ b/awq/models/_config.py
@@ -1,5 +1,6 @@
 import os
 import json
+import logging
 from typing import Dict
 from dataclasses import dataclass, field, fields
 from transformers.utils.hub import PushToHubMixin, cached_file
@@ -14,6 +15,10 @@ class AwqConfig(PushToHubMixin):
     config_file_name = "quant_config.json"
 
     def save_pretrained(self, save_dir: str, **kwargs):
+        logging.warning(
+            "`quant_config.json` is being deprecated in the future"
+            " in favor of quantization_config in config.json."
+        )
         with open(os.path.join(save_dir, self.config_file_name), "w+", encoding="utf-8") as file:
             file.write(json.dumps(self.to_dict(), indent=4))
     

--- a/awq/models/aquila.py
+++ b/awq/models/aquila.py
@@ -1,6 +1,5 @@
 ## Reference from llama.py
 from .base import BaseAWQForCausalLM
-from typing import Dict
 from transformers.models.llama.modeling_llama import (
     LlamaDecoderLayer as AquilaDecoderLayer,
     LlamaForCausalLM as AquilaForCausalLM,
@@ -14,8 +13,8 @@ class AquilaAWQForCausalLM(BaseAWQForCausalLM):
     max_new_tokens_key = "max_position_embeddings"
 
     @staticmethod
-    def fuse_layers(model: AquilaForCausalLM, quant_config: Dict):
-        fuser = AquilaFuser(model, quant_config)
+    def fuse_layers(model: AquilaForCausalLM):
+        fuser = AquilaFuser(model)
         fuser.fuse_attention()
         fuser.fuse_rmsnorm()
         fuser.fuse_mlp()
@@ -82,9 +81,8 @@ from awq.modules.fused.norm import FasterTransformerRMSNorm
 from awq.modules.linear import WQLinear_GEMM, WQLinear_GEMV
 
 class AquilaFuser:
-    def __init__(self, model, quant_config):
+    def __init__(self, model):
         self.model = model
-        self.quant_config = quant_config
 
         self.attention_modules: List[Tuple[str, AquilaAttention]] = [
             (name, module) for name, module in self.model.named_modules()

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -62,8 +62,10 @@ class BaseAWQForCausalLM(nn.Module):
             def __init__(self): super(EmptyModule, self).__init__()
             def forward(self, x): return x
 
-        # Save model files with empty state dict
+        # Save model and config files with empty state dict
+        self.model.config.quantization_config = self.quant_config.to_transformers_dict()
         self.model.save_pretrained(save_dir, state_dict=EmptyModule().state_dict())
+        self.quant_config.save_pretrained(save_dir)
 
         # Remove empty state dict
         os.remove(f'{save_dir}/pytorch_model.bin')
@@ -90,9 +92,6 @@ class BaseAWQForCausalLM(nn.Module):
         if index is not None:
             with open(f'{save_dir}/{model_name}.index.json', 'w+') as file:
                 file.write(json.dumps(index, indent=4))
-
-        # NOTE: Must run after saving model.
-        self.quant_config.save_pretrained(save_dir)
         
         
     @classmethod

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -51,7 +51,7 @@ class BaseAWQForCausalLM(nn.Module):
         self.is_quantized = True
     
     @staticmethod
-    def fuse_layers(model, quant_config):
+    def fuse_layers(model):
         pass
 
     def save_quantized(self, save_dir, safetensors=False, shard_size="10GB"):
@@ -169,7 +169,7 @@ class BaseAWQForCausalLM(nn.Module):
         
         # Dispath to devices
         if fuse_layers:
-            self.fuse_layers(model, quant_config)
+            self.fuse_layers(model)
 
         # Offloading dispatch
         from accelerate import dispatch_model

--- a/awq/models/falcon.py
+++ b/awq/models/falcon.py
@@ -1,12 +1,11 @@
 from .base import BaseAWQForCausalLM
-from typing import Dict
 from transformers.models.falcon.modeling_falcon import FalconDecoderLayer as OldFalconDecoderLayer, FalconForCausalLM, FalconAttention
 
 class FalconAWQForCausalLM(BaseAWQForCausalLM):
     layer_type = "FalconDecoderLayer"
 
     @staticmethod
-    def fuse_layers(model: FalconForCausalLM, quant_config: Dict):
+    def fuse_layers(model: FalconForCausalLM):
         fuser = FalconFuser(model)
 
         # TODO: Implement correctly fused modules for Falcon 40B and Falcon 180B

--- a/awq/models/llama.py
+++ b/awq/models/llama.py
@@ -1,5 +1,4 @@
 from .base import BaseAWQForCausalLM
-from typing import Dict
 from transformers.models.llama.modeling_llama import LlamaDecoderLayer, LlamaForCausalLM
 
 class LlamaAWQForCausalLM(BaseAWQForCausalLM):
@@ -7,8 +6,8 @@ class LlamaAWQForCausalLM(BaseAWQForCausalLM):
     max_new_tokens_key = "max_position_embeddings"
 
     @staticmethod
-    def fuse_layers(model: LlamaForCausalLM, quant_config: Dict):
-        fuser = LlamaFuser(model, quant_config)
+    def fuse_layers(model: LlamaForCausalLM):
+        fuser = LlamaFuser(model)
         fuser.fuse_attention()
         fuser.fuse_rmsnorm()
         fuser.fuse_mlp()
@@ -76,9 +75,8 @@ from awq.modules.linear import WQLinear_GEMM, WQLinear_GEMV
 from transformers.models.llama.modeling_llama import LlamaAttention, LlamaRMSNorm, LlamaMLP
 
 class LlamaFuser:
-    def __init__(self, model, quant_config):
+    def __init__(self, model):
         self.model = model
-        self.quant_config = quant_config
 
         self.attention_modules: List[Tuple[str, LlamaAttention]] = [
             (name, module) for name, module in self.model.named_modules()

--- a/awq/models/mistral.py
+++ b/awq/models/mistral.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from .base import BaseAWQForCausalLM
 from transformers.models.mistral.modeling_mistral import MistralDecoderLayer, MistralForCausalLM
 
@@ -7,8 +6,8 @@ class MistralAWQForCausalLM(BaseAWQForCausalLM):
     max_new_tokens_key = "max_position_embeddings"
 
     @staticmethod
-    def fuse_layers(model: MistralForCausalLM, quant_config: Dict):
-        fuser = MistralFuser(model, quant_config)
+    def fuse_layers(model: MistralForCausalLM):
+        fuser = MistralFuser(model)
         fuser.fuse_attention()
         fuser.fuse_rmsnorm()
         fuser.fuse_mlp()
@@ -76,9 +75,8 @@ from awq.modules.linear import WQLinear_GEMM, WQLinear_GEMV
 from transformers.models.mistral.modeling_mistral import MistralAttention, MistralRMSNorm, MistralMLP
 
 class MistralFuser:
-    def __init__(self, model, quant_config):
+    def __init__(self, model):
         self.model = model
-        self.quant_config = quant_config
 
         self.attention_modules: List[Tuple[str, MistralAttention]] = [
             (name, module) for name, module in self.model.named_modules()

--- a/awq/models/mpt.py
+++ b/awq/models/mpt.py
@@ -1,5 +1,4 @@
 from .base import BaseAWQForCausalLM
-from typing import Dict
 from transformers.models.mpt.modeling_mpt import MptBlock as OldMptBlock, MptForCausalLM
 
 class MptAWQForCausalLM(BaseAWQForCausalLM):
@@ -7,7 +6,7 @@ class MptAWQForCausalLM(BaseAWQForCausalLM):
     max_new_tokens_key = "max_seq_len"
 
     @staticmethod
-    def fuse_layers(model: MptForCausalLM, quant_config: Dict):
+    def fuse_layers(model: MptForCausalLM):
         fuser = MptFuser(model)
         fuser.fuse_transformer()
 

--- a/examples/basic_transformers.py
+++ b/examples/basic_transformers.py
@@ -1,0 +1,29 @@
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, TextStreamer
+
+# NOTE: Must install from PR until merged
+# pip install --upgrade git+https://github.com/younesbelkada/transformers.git@add-awq
+model_id = "casperhansen/mistral-7b-instruct-v0.1-awq"
+
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+model = AutoModelForCausalLM.from_pretrained(
+    model_id, 
+    torch_dtype=torch.float16, 
+    low_cpu_mem_usage=True
+).cuda()
+streamer = TextStreamer(tokenizer, skip_prompt=True, skip_special_tokens=True)
+
+# Convert prompt to tokens
+text = "[INST] What are the basic steps to use the Huggingface transformers library? [/INST]"
+
+tokens = tokenizer(
+    text, 
+    return_tensors='pt'
+).input_ids.cuda()
+
+# Generate output
+generation_output = model.generate(
+    tokens, 
+    streamer=streamer,
+    max_new_tokens=512
+)

--- a/examples/basic_transformers.py
+++ b/examples/basic_transformers.py
@@ -9,8 +9,9 @@ tokenizer = AutoTokenizer.from_pretrained(model_id)
 model = AutoModelForCausalLM.from_pretrained(
     model_id, 
     torch_dtype=torch.float16, 
-    low_cpu_mem_usage=True
-).cuda()
+    low_cpu_mem_usage=True,
+    device_map="cuda:0"
+)
 streamer = TextStreamer(tokenizer, skip_prompt=True, skip_special_tokens=True)
 
 # Convert prompt to tokens

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -126,8 +126,8 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_path", type=str, default="casperhansen/vicuna-7b-v1.5-awq", help="path to the model")
-    parser.add_argument("--quant_file", type=str, default="awq_model_w4_g128.pt", help="weights filename")
+    parser.add_argument("--model_path", type=str, default="casperhansen/mistral-7b-instruct-v0.1-awq", help="path to the model")
+    parser.add_argument("--quant_file", type=str, default="", help="weights filename")
     parser.add_argument("--batch_size", type=int, default=1, help="Batch size for cache and generation")
     parser.add_argument("--safetensors", default=False, action="store_true", help="Use for enabling safetensors")
     args = parser.parse_args()

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -85,7 +85,7 @@ def run_round(model_path, quant_file, n_generate, input_ids, batch_size, safeten
         "Prefill tokens/s": prefill_tokens_per_second,
         "Decode tokens/s": decode_tokens_per_second,
         "Memory (VRAM)": f"{memory_used:.2f} GB ({memory_pct:.2f}%)"
-    }, model.quant_config["version"]
+    }, model.quant_config.version
 
 def main(args):
     rounds = [

--- a/examples/eval.py
+++ b/examples/eval.py
@@ -33,7 +33,7 @@ def run_eval(model_path, quant_file, device, tasks, task_batch_size, task_n_shot
 if __name__ == '__main__':
     """
     - Run perplexity of quantized model:
-    python examples/eval.py --model_path vicuna-7b-v1.5-awq --quant_file awq_model_w4_g128.pt
+    python examples/eval.py --model_path casperhansen/mistral-7b-instruct-v0.1-awq
 
     - Run perplexity unquantized FP16 model:
     python examples/eval.py --use_pretrained --model_path lmsys/vicuna-7b-v1.5


### PR DESCRIPTION
This PR is created to make any new AutoAWQ model automatically compatible with `transformers` following the PR to merge AutoAWQ inference into the core of transformers: https://github.com/huggingface/transformers/pull/27045.

- Creates `AwqQuantConfig` that separates all the loading and saving from the base AWQ class.
- Saves both `quant_config.json` and puts the `quantization_config` key directly into `config.json`
- Inspired by AutoGPTQ's config class and #91. Closes #8.