### PR TITLE
[`core` / `attention`] Fix fused attention generation with newest transformers version

### DIFF
--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -171,7 +171,8 @@ class QuantAttentionFused(nn.Module):
             self.cache.update_kv(values_store, keys_store, bsz, self.start_pos, seqlen)
 
             if seqlen == 1:
-                xv, xk = self.cache.get_kv(bsz, self.start_pos, past_kv_len, self.head_dim)
+                xv, xk = self.cache.get_kv(bsz, self.start_pos, seqlen, self.head_dim)
+
             
             keys = xk
             values = xv

--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -190,7 +190,6 @@ class QuantAttentionFused(nn.Module):
 
             # When seqlen is 1, there is nothing else to attend to
             if attention_mask is not None and seqlen > 1:
-                # scores = scores + attention_mask[:, :, :, :scores.shape[-1]]  # (bs, n_local_heads, slen, cache_len + slen)
                 scores = scores + attention_mask  # (bs, n_local_heads, slen, cache_len + slen)
             scores = F.softmax(scores.float(), dim=-1).type_as(xq)
             output = torch.matmul(scores, values)  # (bs, n_local_heads, slen, head_dim)


### PR DESCRIPTION
# What does this PR do?

Currently in the latest transformers release, using AutoAWQ + fused attention with cache is broken
In https://github.com/huggingface/transformers/pull/25242/ the logic of caching has changed a bit, now when using transformers cache + a past key value length of 1 (as done here), the input ids will be sliced as such:

```python
input_ids = input_ids[:, 1:]
```

Meaning the assumption `if seqlen == 1:` to deal with the transformers cache case needs now to be adapted, one can just check if `past_key_values` is present in kwargs and contains valid tensors, and slice out only the last token if that's the case

cc @casper-hansen 