### PR TITLE
Fix performance regression

### DIFF
--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -129,11 +129,11 @@ class QuantAttentionFused(nn.Module):
             )
 
         will_cache_be_exceeded = self.start_pos + seqlen > self.max_seq_len
-        
+
         # Reset and avoid retaining state when processing context
         if will_cache_be_exceeded:
             self.start_pos = self.cache.roll_kv_n_steps(self.start_pos, n=self.start_pos)
-        # Slowly roll out old tokens if exceeded during decoding without performance hit
+        # Slowly roll out old tokens without performance hit if exceeded during decoding 
         elif will_cache_be_exceeded and seqlen == 1:
             self.start_pos = self.cache.roll_kv_n_steps(self.start_pos, n=100)
             

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -112,7 +112,6 @@ def main(args):
             args.batch_size,
             args.safetensors
         )
-        break
         
         all_stats.append(stats)
 

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -85,7 +85,7 @@ def run_round(model_path, quant_file, n_generate, input_ids, batch_size, safeten
         "Prefill tokens/s": prefill_tokens_per_second,
         "Decode tokens/s": decode_tokens_per_second,
         "Memory (VRAM)": f"{memory_used:.2f} GB ({memory_pct:.2f}%)"
-    }, model.quant_config["version"]
+    }, model.quant_config.version
 
 def main(args):
     rounds = [
@@ -112,6 +112,7 @@ def main(args):
             args.batch_size,
             args.safetensors
         )
+        break
         
         all_stats.append(stats)
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ PYPI_BUILD = os.getenv("PYPI_BUILD", "0") == "1"
 if not PYPI_BUILD:
     try:
         CUDA_VERSION = "".join(os.environ.get("CUDA_VERSION", torch.version.cuda).split("."))[:3]
-        AUTOAWQ_VERSION += f"cu+{CUDA_VERSION}"
+        AUTOAWQ_VERSION += f"+cu{CUDA_VERSION}"
     except Exception as ex:
         raise RuntimeError("Your system must have an Nvidia GPU for installing AutoAWQ")
 


### PR DESCRIPTION
#95 refactored the cache and simultaneously caused a regression in performance that was not caught before release. This patch rolls back the regression and improves the caching behaviour during decoding to not take large performance hits.