### PR TITLE
Build older cuda wheels

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,40 +2,40 @@ name: Build AutoAWQ Wheels with CUDA
 
 on:
   push:
-    branches:
-      - older_cuda_wheels
+    tags:
+      - "v*"
 
 jobs:
-  # release:
-  #   # Retrieve tag and create release
-  #   name: Create Release
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
+  release:
+    # Retrieve tag and create release
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - name: Extract branch info
-  #       shell: bash
-  #       run: |
-  #         echo "release_tag=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Extract branch info
+        shell: bash
+        run: |
+          echo "release_tag=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-  #     - name: Create Release
-  #       id: create_release
-  #       uses: "actions/github-script@v6"
-  #       env:
-  #         RELEASE_TAG: ${{ env.release_tag }}
-  #       with:
-  #         github-token: "${{ secrets.GITHUB_TOKEN }}"
-  #         script: |
-  #           const script = require('.github/workflows/scripts/github_create_release.js')
-  #           await script(github, context, core)
+      - name: Create Release
+        id: create_release
+        uses: "actions/github-script@v6"
+        env:
+          RELEASE_TAG: ${{ env.release_tag }}
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            const script = require('.github/workflows/scripts/github_create_release.js')
+            await script(github, context, core)
 
   build_wheels:
     name: Build AWQ
     runs-on: ${{ matrix.os }}
-    # needs: release
+    needs: release
     
     strategy:
       matrix:
@@ -114,13 +114,8 @@ jobs:
 
           python setup.py sdist bdist_wheel
       
-      - uses: actions/upload-artifact@v3
+      - name: Upload Assets
+        uses: shogo82148/actions-upload-release-asset@v1
         with:
-          name: 'wheels'
-          path: ./dist/*.whl
-      
-      # - name: Upload Assets
-      #   uses: shogo82148/actions-upload-release-asset@v1
-      #   with:
-      #     upload_url: ${{ needs.release.outputs.upload_url }}
-      #     asset_path: ./dist/*.whl
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./dist/*.whl

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,7 @@ jobs:
           $env:CUDA_HOME = $env:CONDA_PREFIX
 
           # Only add +cu118 to wheel if not releasing on PyPi
-          if ( env:CUDA_VERSION = env:PYPI_CUDA_VERSION ){
+          if ( $env:CUDA_VERSION = $env:PYPI_CUDA_VERSION ){
             $env:PYPI_BUILD = 1
           }
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
           # Install torch
           $cudaVersion = $env:CUDA_VERSION.Replace('.', '')
           $cudaVersionPytorch = $cudaVersion.Substring(0, $cudaVersion.Length - 1)
-          $pytorchVersion = "torch==2.1.0"
+          if ([int]$cudaVersionPytorch -gt 118) { $pytorchVersion = "torch==2.1.0" } else {$pytorchVersion = "torch==2.0.1"}
           python -m pip install --upgrade --no-cache-dir $pytorchVersion+cu$cudaVersionPytorch --index-url https://download.pytorch.org/whl/cu$cudaVersionPytorch
           python -m pip install build setuptools wheel ninja
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,7 @@ jobs:
           $env:CUDA_HOME = $env:CONDA_PREFIX
 
           # Only add +cu118 to wheel if not releasing on PyPi
-          if ( $env:CUDA_VERSION = $env:PYPI_CUDA_VERSION ){
+          if ( $env:CUDA_VERSION -eq $env:PYPI_CUDA_VERSION ){
             $env:PYPI_BUILD = 1
           }
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,51 +2,52 @@ name: Build AutoAWQ Wheels with CUDA
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - older_cuda_wheels
 
 jobs:
-  release:
-    # Retrieve tag and create release
-    name: Create Release
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+  # release:
+  #   # Retrieve tag and create release
+  #   name: Create Release
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
 
-      - name: Extract branch info
-        shell: bash
-        run: |
-          echo "release_tag=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+  #     - name: Extract branch info
+  #       shell: bash
+  #       run: |
+  #         echo "release_tag=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-      - name: Create Release
-        id: create_release
-        uses: "actions/github-script@v6"
-        env:
-          RELEASE_TAG: ${{ env.release_tag }}
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          script: |
-            const script = require('.github/workflows/scripts/github_create_release.js')
-            await script(github, context, core)
+  #     - name: Create Release
+  #       id: create_release
+  #       uses: "actions/github-script@v6"
+  #       env:
+  #         RELEASE_TAG: ${{ env.release_tag }}
+  #       with:
+  #         github-token: "${{ secrets.GITHUB_TOKEN }}"
+  #         script: |
+  #           const script = require('.github/workflows/scripts/github_create_release.js')
+  #           await script(github, context, core)
 
   build_wheels:
     name: Build AWQ
     runs-on: ${{ matrix.os }}
-    needs: release
+    # needs: release
     
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest]
         pyver: ["3.8", "3.9", "3.10", "3.11"]
-        cuda: ["12.1.1"]
+        cuda: ["11.8.0", "12.1.1"]
     defaults:
       run:
         shell: pwsh
     env:
-        CUDA_VERSION: ${{ matrix.cuda }}
+      PYPI_CUDA_VERSION: "12.1.1"  
+      CUDA_VERSION: ${{ matrix.cuda }}
     
     steps:
       - name: Free Disk Space
@@ -90,7 +91,7 @@ jobs:
           # Install torch
           $cudaVersion = $env:CUDA_VERSION.Replace('.', '')
           $cudaVersionPytorch = $cudaVersion.Substring(0, $cudaVersion.Length - 1)
-          if ([int]$cudaVersionPytorch -gt 118) { $pytorchVersion = "torch==2.1.0" } else {$pytorchVersion = "torch==2.0.1"}
+          $pytorchVersion = "torch==2.1.0"
           python -m pip install --upgrade --no-cache-dir $pytorchVersion+cu$cudaVersionPytorch --index-url https://download.pytorch.org/whl/cu$cudaVersionPytorch
           python -m pip install build setuptools wheel ninja
 
@@ -105,12 +106,21 @@ jobs:
         run: |
           $env:CUDA_PATH = $env:CONDA_PREFIX
           $env:CUDA_HOME = $env:CONDA_PREFIX
-          $env:PYPI_BUILD = 1
+
+          # Only add +cu118 to wheel if not releasing on PyPi
+          if ( env:CUDA_VERSION = env:PYPI_CUDA_VERSION ){
+            $env:PYPI_BUILD = 1
+          }
 
           python setup.py sdist bdist_wheel
       
-      - name: Upload Assets
-        uses: shogo82148/actions-upload-release-asset@v1
+      - uses: actions/upload-artifact@v3
         with:
-          upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: ./dist/*.whl
+          name: 'wheels'
+          path: ./dist/*.whl
+      
+      # - name: Upload Assets
+      #   uses: shogo82148/actions-upload-release-asset@v1
+      #   with:
+      #     upload_url: ${{ needs.release.outputs.upload_url }}
+      #     asset_path: ./dist/*.whl

--- a/README.md
+++ b/README.md
@@ -34,10 +34,21 @@ Requirements:
 ---
 
 Install:
-- Use pip to install awq
+
+- Install from PyPi distributed wheels (torch 2.1.0 + CUDA 12.1.1)
 
 ```
 pip install autoawq
+```
+
+- Install from GitHub a release (torch 2.0.1 + CUDA 11.8.0)
+
+Remember to grab the right link for the [latest release](https://github.com/casper-hansen/AutoAWQ/releases) that matches your environment.
+
+For example, this wheel is torch 2.0.1 with CUDA 11.8.0 and Python 3.10 for Linux:
+
+```
+pip install https://github.com/casper-hansen/AutoAWQ/releases/download/v0.1.6/autoawq-0.1.6+cu118-cp310-cp310-linux_x86_64.whl
 ```
 
 ### Using conda

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ common_setup_kwargs = {
 }
 
 requirements = [
-    "torch>=2.1.0",
+    "torch>=2.0.1",
     "transformers>=4.35.0",
     "tokenizers>=0.12.1",
     "accelerate",


### PR DESCRIPTION
- make PyPi releases that are built with (torch 2.1.0 + CUDA 12.1.1)
- upload additional wheels to the GitHub release (torch 2.0.1 + CUDA 11.8.0)
- modify `setup.py` to specify `torch>=2.0.1`