### PR TITLE
Adaptive batch sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Fused modules are a large part of the speedup you get from AutoAWQ. The idea is 
 
 - Fused modules are activated when you use `fuse_layers=True`.
 - A custom cache is implemented. It preallocates based on batch size and sequence length.
-    - You cannot change the sequence length or batch size after you have created your model.
+    - You cannot change the sequence length after you have created your model.
     - Reference: `AutoAWQForCausalLM.from_quantized(max_new_tokens=seq_len, batch_size=batch_size)`
 - The main accelerator in the fused modules comes from FasterTransformer, which is only compatible with Linux.
 - The `past_key_values` from `model.generate()` are only dummy values, so they cannot be used after generation.

--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -103,7 +103,6 @@ class QuantAttentionFused(nn.Module):
         self.max_seq_len = max_seq_len
 
         # attention shapes for self attention
-        self.last_attention_shapes = attention_shapes
         self.attention_shapes = get_attention_shapes(
             attention_shapes, max_seq_len, self.cache_batch_size, n_heads, n_kv_heads, self.head_dim
         )

--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -1,7 +1,6 @@
 import os
 import math
 import torch
-import logging
 import torch.nn as nn
 from torch.nn import functional as F
 from awq.modules.fused.cache import WindowedCache

--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -125,8 +125,8 @@ class QuantAttentionFused(nn.Module):
     def forward(self, hidden_states:torch.Tensor, attention_mask=None, *args, **kwargs):
         bsz, seqlen, _ = hidden_states.shape
 
+        # Reallocate cache if batch size changes
         if bsz != self.cache_batch_size:
-            # logging.warning("Dynamically reallocating batch size.")
             if bsz > self.cache_batch_size:
                 self.cache.increase_batch_size(bsz)
                 self.cache_batch_size = bsz

--- a/awq/modules/fused/cache.py
+++ b/awq/modules/fused/cache.py
@@ -48,3 +48,12 @@ class WindowedCache:
         self.k = self.k.to(device)
         self.v = self.v.to(device)
     
+    def increase_batch_size(self, to_bsz):
+        """Dynamically allocate new kv when batch size changes."""
+        self.v = torch.zeros(to_bsz, *self.v.shape[1:], dtype=self.v.dtype, device=self.v.device)
+        self.k = torch.zeros(to_bsz, *self.k.shape[1:], dtype=self.k.dtype, device=self.k.device)
+
+    def decrease_batch_size(self, to_bsz):
+        """Dynamically remove part of cache if batch size changes."""
+        self.v = self.v[:to_bsz, :, :, :]
+        self.k = self.k[:to_bsz, :, :, :, :]


### PR DESCRIPTION
Implements adaptive batch sizing, so you can pass in any batch size at any point. Resolves #173 

```python
from awq import AutoAWQForCausalLM
from transformers import AutoTokenizer

quant_path = "TheBloke/zephyr-7B-beta-AWQ"

# Load model
model = AutoAWQForCausalLM.from_quantized(quant_path, fuse_layers=True)
tokenizer = AutoTokenizer.from_pretrained(quant_path, trust_remote_code=True)

# Convert prompt to tokens
prompt_template = """\
<|system|>
</s>
<|user|>
{prompt}</s>
<|assistant|>"""

tokens1 = tokenizer(
    [prompt_template.format(prompt="Capital of France is")], 
    return_tensors='pt',
    padding=True
).input_ids.cuda()

tokens2 = tokenizer(
    [prompt_template.format(prompt="And you are"), prompt_template.format(prompt="Favorite Beatles song?"), prompt_template.format(prompt="Hottest place on earth is")],
    return_tensors='pt',
    padding=True
).input_ids.cuda()

tokens3 = tokenizer(
    [prompt_template.format(prompt="How to test a new car?"), prompt_template.format(prompt="Tell me how amazing Earth is")],
    return_tensors='pt',
    padding=True
).input_ids.cuda()

# Generate output
for tokens in [tokens1, tokens2, tokens3]:
    print(tokens.shape)
    generation_output = model.generate(
        tokens,
        max_new_tokens=128
    )

    for output in generation_output:
        print('###')
        print(tokenizer.decode(output))
```