### PR TITLE
[`core`] Replace `QuantLlamaMLP` with `QuantFusedMLP`

### DIFF
--- a/awq/models/aquila.py
+++ b/awq/models/aquila.py
@@ -8,7 +8,7 @@ from transformers.models.llama.modeling_llama import (
     LlamaDecoderLayer as OldAquilaDecoderLayer,
     LlamaForCausalLM as OldAquilaForCausalLM
 )
-from awq.modules.fused.mlp import QuantLlamaMLP
+from awq.modules.fused.mlp import QuantFusedMLP
 from awq.modules.fused.norm import FasterTransformerRMSNorm
 
 class AquilaAWQForCausalLM(BaseAWQForCausalLM):
@@ -95,7 +95,7 @@ class AquilaFuser:
                 module.self_attn.k_proj,
                 module.self_attn.v_proj
             )
-            mlp = QuantLlamaMLP(
+            mlp = QuantFusedMLP(
                 module.mlp.gate_proj,
                 module.mlp.down_proj,
                 module.mlp.up_proj

--- a/awq/models/llama.py
+++ b/awq/models/llama.py
@@ -8,7 +8,7 @@ from transformers.models.llama.modeling_llama import (
     LlamaDecoderLayer as OldLlamaDecoderLayer,
     LlamaForCausalLM as OldLlamaForCausalLM
 )
-from awq.modules.fused.mlp import QuantLlamaMLP
+from awq.modules.fused.mlp import QuantFusedMLP
 from awq.modules.fused.norm import FasterTransformerRMSNorm
 
 class LlamaAWQForCausalLM(BaseAWQForCausalLM):
@@ -95,7 +95,7 @@ class LlamaFuser:
                 module.self_attn.k_proj,
                 module.self_attn.v_proj
             )
-            mlp = QuantLlamaMLP(
+            mlp = QuantFusedMLP(
                 module.mlp.gate_proj,
                 module.mlp.down_proj,
                 module.mlp.up_proj

--- a/awq/models/mistral.py
+++ b/awq/models/mistral.py
@@ -8,7 +8,7 @@ from transformers.models.mistral.modeling_mistral import (
     MistralDecoderLayer as OldMistralDecoderLayer,
     MistralForCausalLM as OldMistralForCausalLM
 )
-from awq.modules.fused.mlp import QuantLlamaMLP
+from awq.modules.fused.mlp import QuantFusedMLP
 from awq.modules.fused.norm import FasterTransformerRMSNorm
 
 class MistralAWQForCausalLM(BaseAWQForCausalLM):
@@ -95,7 +95,7 @@ class MistralFuser:
                 module.self_attn.k_proj,
                 module.self_attn.v_proj
             )
-            mlp = QuantLlamaMLP(
+            mlp = QuantFusedMLP(
                 module.mlp.gate_proj,
                 module.mlp.down_proj,
                 module.mlp.up_proj

--- a/awq/models/yi.py
+++ b/awq/models/yi.py
@@ -4,7 +4,7 @@ from .base import BaseAWQForCausalLM
 from awq.utils.fused_utils import fuse_qkv
 from awq.modules.fused.block import LlamaLikeBlock
 from awq.modules.fused.model import LlamaLikeModel
-from awq.modules.fused.mlp import QuantLlamaMLP
+from awq.modules.fused.mlp import QuantFusedMLP
 from awq.modules.fused.norm import FasterTransformerRMSNorm
 
 class YiAWQForCausalLM(BaseAWQForCausalLM):
@@ -90,7 +90,7 @@ class YiFuser:
                 module.self_attn.k_proj,
                 module.self_attn.v_proj
             )
-            mlp = QuantLlamaMLP(
+            mlp = QuantFusedMLP(
                 module.mlp.gate_proj,
                 module.mlp.down_proj,
                 module.mlp.up_proj

--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -131,7 +131,16 @@ class QuantAttentionFused(nn.Module):
             elif bsz < self.cache_batch_size:
                 self.cache.decrease_batch_size(bsz)
                 self.cache_batch_size = bsz
-            
+
+            # Always reset to 0
+            self.start_pos = 0 
+
+        # In case we re-generate, we need to refresh the starting position 
+        # to 0. We detect it by checking if `past_key_values` is set to None, 
+        # which indicates that we are on the first step of `generate()`.
+        if"past_key_value" in kwargs and kwargs["past_key_value"] is None:
+            self.start_pos = 0
+
         xqkv = self.qkv_proj(hidden_states)
         xqkv = xqkv.view((bsz, seqlen) + self.attention_shapes["xqkv_view"])
         

--- a/awq/modules/fused/mlp.py
+++ b/awq/modules/fused/mlp.py
@@ -10,7 +10,7 @@ class QuantFusedMLP(nn.Module):
         gate_proj,
         down_proj,
         up_proj,
-        activation,
+        activation = F.silu,
     ):
         super().__init__()
 
@@ -71,4 +71,4 @@ class QuantLlamaMLP(QuantFusedMLP):
         down_proj,
         up_proj
     ):
-        super().__init__(gate_proj, down_proj, up_proj, F.silu)
+        super().__init__(gate_proj, down_proj, up_proj)


### PR DESCRIPTION
In the context of https://github.com/huggingface/transformers/pull/27411 I wanted to create a more generic class for fused MLP layers. I kept the previous `QuantLlamaMLP` for backward compatiblity

cc @casper-hansen 

This PR also fixed another issue where users face a strange issue whenever they try to perform multi-turn generation.