### PR TITLE
Fix multi-GPU loading and inference

### DIFF
--- a/awq/models/auto.py
+++ b/awq/models/auto.py
@@ -45,13 +45,13 @@ class AutoAWQForCausalLM:
     def from_quantized(self, quant_path, quant_filename='', max_new_tokens=None,
                        trust_remote_code=True, fuse_layers=True,
                        batch_size=1, safetensors=True,
-                       max_memory=None, offload_folder=None, **config_kwargs) -> BaseAWQForCausalLM:
+                       device_map="balanced", offload_folder=None, **config_kwargs) -> BaseAWQForCausalLM:
         os.environ["AWQ_BATCH_SIZE"] = str(batch_size)
         model_type = check_and_get_model_type(quant_path, trust_remote_code)
 
         return AWQ_CAUSAL_LM_MODEL_MAP[model_type].from_quantized(
             quant_path, model_type, quant_filename, max_new_tokens, trust_remote_code=trust_remote_code, 
             fuse_layers=fuse_layers, safetensors=safetensors, 
-            max_memory=max_memory, offload_folder=offload_folder,
+            device_map=device_map, offload_folder=offload_folder,
             **config_kwargs
         )

--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -180,7 +180,7 @@ class QuantAttentionFused(nn.Module):
 
             # When seqlen is 1, there is nothing else to attend to
             if attention_mask is not None and seqlen > 1:
-                scores = scores + attention_mask.to(scores.device)  # (bs, n_local_heads, slen, cache_len + slen)
+                scores = scores + attention_mask  # (bs, n_local_heads, slen, cache_len + slen)
             scores = F.softmax(scores.float(), dim=-1).type_as(xq)
             output = torch.matmul(scores, values)  # (bs, n_local_heads, slen, head_dim)
             attention_weight = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)

--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -180,7 +180,7 @@ class QuantAttentionFused(nn.Module):
 
             # When seqlen is 1, there is nothing else to attend to
             if attention_mask is not None and seqlen > 1:
-                scores = scores + attention_mask  # (bs, n_local_heads, slen, cache_len + slen)
+                scores = scores + attention_mask.to(scores.device)  # (bs, n_local_heads, slen, cache_len + slen)
             scores = F.softmax(scores.float(), dim=-1).type_as(xq)
             output = torch.matmul(scores, values)  # (bs, n_local_heads, slen, head_dim)
             attention_weight = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)

--- a/awq/modules/fused/block.py
+++ b/awq/modules/fused/block.py
@@ -19,6 +19,7 @@ class LlamaLikeBlock(nn.Module):
         ).to(dev)
         self.norm_2 = norm_2.to(dev)
         self.mlp = mlp.to(dev)
+        self.device = dev
 
     def forward(
         self, hidden_states, past_key_value, attn_bias=None, attention_mask=None, is_causal=None
@@ -48,6 +49,7 @@ class MPTBlock(nn.Module):
         ).to(dev)
         self.norm_2 = norm_2
         self.ffn = mpt_mlp.to(dev)
+        self.device = dev
 
     def forward(
         self, hidden_states, past_key_value, attn_bias=None, attention_mask=None, is_causal=None
@@ -94,6 +96,7 @@ class FalconDecoderLayer(nn.Module):
             self.input_layernorm = input_layernorm # before attention
         
         self.mlp = mlp
+        self.device = dev
     
     def _get_attention_shapes(self, n_heads, max_seq_len, head_dim):
         batch_size = int(os.getenv("AWQ_BATCH_SIZE", "1"))

--- a/awq/modules/fused/block.py
+++ b/awq/modules/fused/block.py
@@ -30,7 +30,7 @@ class LlamaLikeBlock(nn.Module):
             attention_mask=attention_mask
         )
 
-        h = hidden_states + attn_output
+        h = hidden_states.to(attn_output.device) + attn_output
         out = h + self.mlp.forward(self.norm_2(h))
 
         return out, None, past_key_value
@@ -62,7 +62,7 @@ class MPTBlock(nn.Module):
             use_cache=True
         )
 
-        h = hidden_states + attn_output
+        h = hidden_states.to(attn_output.device) + attn_output
         out = h + self.ffn.forward(self.norm_2(h))
         return out, None, past_key_value
 
@@ -136,7 +136,7 @@ class FalconDecoderLayer(nn.Module):
             use_cache=True
         )
 
-        h_attn = hidden_states + attn_output
+        h_attn = hidden_states.to(attn_output.device) + attn_output
 
         if self.new_decoder_arch:
             h_mlp = self.mlp.forward(mlp_layernorm_out)

--- a/awq/modules/linear.py
+++ b/awq/modules/linear.py
@@ -102,7 +102,6 @@ class WQLinear_GEMM(nn.Module):
         if input_dtype != torch.float16:
             x = x.half()
         
-        x = x.to(self.qweight.device)
         out = awq_inference_engine.gemm_forward_cuda(x.reshape(-1, x.shape[-1]), self.qweight, self.scales, self.qzeros, 8)
         
         if input_dtype != torch.float16:
@@ -209,8 +208,6 @@ class WQLinear_GEMV(nn.Module):
         input_dtype = inputs.dtype
         if input_dtype != torch.float16:
             inputs = inputs.half()
-        
-        inputs = inputs.to(self.qweight.device)
         
         if inputs.shape[0] > 8:
             out = awq_inference_engine.gemmv2_forward_cuda(inputs, self.qweight, self.scales, self.qzeros, self.group_size, self.split_k_iters)

--- a/awq/modules/linear.py
+++ b/awq/modules/linear.py
@@ -101,7 +101,8 @@ class WQLinear_GEMM(nn.Module):
         input_dtype = x.dtype
         if input_dtype != torch.float16:
             x = x.half()
-
+        
+        x = x.to(self.qweight.device)
         out = awq_inference_engine.gemm_forward_cuda(x.reshape(-1, x.shape[-1]), self.qweight, self.scales, self.qzeros, 8)
         
         if input_dtype != torch.float16:
@@ -208,6 +209,8 @@ class WQLinear_GEMV(nn.Module):
         input_dtype = inputs.dtype
         if input_dtype != torch.float16:
             inputs = inputs.half()
+        
+        inputs = inputs.to(self.qweight.device)
         
         if inputs.shape[0] > 8:
             out = awq_inference_engine.gemmv2_forward_cuda(inputs, self.qweight, self.scales, self.qzeros, self.group_size, self.split_k_iters)

--- a/awq/utils/fused_utils.py
+++ b/awq/utils/fused_utils.py
@@ -1,6 +1,15 @@
 import torch
+from typing import List
 from awq.modules.linear import WQLinear_GEMM, WQLinear_GEMV
 
+def prepare_correct_devices(next_layer, hidden_states, mask):
+    hidden_states = hidden_states.to(next_layer.device)
+
+    if mask is not None:
+        mask = mask.to(next_layer.device)
+
+    return hidden_states, mask
+    
 def prepare_cache(blocks, seqlen: int) -> int:
     for block in blocks:
         start_pos = block.attn.start_pos


### PR DESCRIPTION
Resolves #162, Resolves #131, Resolves #143

- update the use of accelerate methods for multi-GPU (they broke at some point)
- fix memory issues related to multi-GPU
    - `cuda error: an illegal memory access was encountered`: This was caused by tensors not being on the right devices. The solution is to put tensors on the right device at the model level - doing it at the linear module level was not a full fix.
- note: `hidden_states.to(attn_output.device) + attn_output` may not be needed, needs more testing to make sure it is needed