### PR TITLE
FEAT: Add possibility of skipping modules when quantizing

### DIFF
--- a/awq/models/_config.py
+++ b/awq/models/_config.py
@@ -1,7 +1,7 @@
 import os
 import json
 import logging
-from typing import Dict
+from typing import Dict, Optional, List
 from dataclasses import dataclass, field, fields
 from transformers.utils.hub import PushToHubMixin, cached_file
 
@@ -13,6 +13,7 @@ class AwqConfig(PushToHubMixin):
     w_bit: int = field(default=4)
     version: str = field(default="GEMM")
     config_file_name = "quant_config.json"
+    modules_to_not_convert: Optional[List] = None
 
     def save_pretrained(self, save_dir: str, **kwargs):
         logging.warning(
@@ -76,7 +77,8 @@ class AwqConfig(PushToHubMixin):
             "zero_point": self.zero_point,
             "q_group_size": self.q_group_size,
             "w_bit": self.w_bit,
-            "version": self.version
+            "version": self.version,
+            "modules_to_not_convert": self.modules_to_not_convert,
         }
 
     def to_transformers_dict(self):
@@ -86,4 +88,5 @@ class AwqConfig(PushToHubMixin):
             "group_size": self.q_group_size,
             "bits": self.w_bit,
             "version": self.version.lower(),
+            "modules_to_not_convert": self.modules_to_not_convert,
         }

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -49,12 +49,12 @@ class BaseAWQForCausalLM(nn.Module):
     @torch.no_grad()
     def quantize(self, tokenizer=None, quant_config={},
                        calib_data: Union[str, List[str]]="pileval", 
-                       split="train", text_column="text", duo_scaling=True):
+                       split="train", text_column="text", duo_scaling=True, modules_to_not_convert=None):
         self.quant_config: AwqConfig = AwqConfig.from_dict(quant_config)
 
         quantizer = AwqQuantizer(
             self, self.model, tokenizer, self.quant_config.w_bit, self.quant_config.q_group_size,
-            self.quant_config.version, calib_data, split, text_column, duo_scaling
+            self.quant_config.version, calib_data, split, text_column, duo_scaling, modules_to_not_convert=modules_to_not_convert
         )
         quantizer.quantize()
         self.is_quantized = True

--- a/awq/quantize/scale.py
+++ b/awq/quantize/scale.py
@@ -53,8 +53,10 @@ def apply_scale(module, scales_list, input_feat_dict=None):
         # apply the scaling to input feat if given; prepare it for clipping
         if input_feat_dict is not None:  
             for layer_name in layer_names:
-                inp = input_feat_dict[layer_name]
-                inp.div_(scales.view(1, -1).to(inp.device))
+                # Skip the modules that are not quantized
+                if layer_name in input_feat_dict:
+                    inp = input_feat_dict[layer_name]
+                    inp.div_(scales.view(1, -1).to(inp.device))
 
         prev_op.cpu()
         for layer in layers:


### PR DESCRIPTION
# What does this PR do?

For some models (e.g., Whisper, Mixtral or Llava) it is important to skip some modules during quantization. This PR adds the experimental support for skipping modules during quantization with the following API. 


```py
from awq import AutoAWQForCausalLM
from transformers import AutoTokenizer, AwqConfig

model_path = "facebook/opt-125m"
quant_path = "test-quant/opt-125m-awq-no-kproj"
modules_to_not_convert = ["k_proj"]

quant_config = {"zero_point": True, "q_group_size": 128, "w_bit": 4, "version":"GEMM", "modules_to_not_convert": modules_to_not_convert}

# Load model
model = AutoAWQForCausalLM.from_pretrained(model_path)
tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)

# Quantize
model.quantize(tokenizer, quant_config=quant_config, modules_to_not_convert=modules_to_not_convert)
```

An example model has been pushed here: https://huggingface.co/ybelkada/opt-125m-awq-no-k-proj and works fine with a PR of transformers that I will open soon.

cc @casper-hansen @TheBloke