### PR TITLE
[`core`] Fix quantization issues with transformers==4.36.0

### DIFF
--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -343,6 +343,8 @@ class AwqQuantizer:
         except ValueError:  # work with early exit
             pass
         
+        # Update the layer kwargs with `prepare_inputs_for_generation` method
+        # that takes care of everything to avoid unexpected errors.
         layer_kwargs = self.model.prepare_inputs_for_generation(samples, **layer_kwargs)
         # Pop the input_ids as they are not needed at all.
         layer_kwargs.pop("input_ids")

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -342,6 +342,11 @@ class AwqQuantizer:
             self.model(samples.to(next(self.model.parameters()).device))
         except ValueError:  # work with early exit
             pass
+        
+        layer_kwargs = self.model.prepare_inputs_for_generation(samples, **layer_kwargs)
+        # Pop the input_ids as they are not needed at all.
+        layer_kwargs.pop("input_ids")
+
         del samples
         modules[0] = modules[0].module  # restore
         inps = inps[0]


### PR DESCRIPTION
# What does this PR do?

The recent transformers release that included a cache refactor: https://github.com/huggingface/transformers/pull/26681/ broke some internal assumptions in autoawq about the shapes of attention masks and input embeddings.

This PR fixes this issue by simply updating `layer_kwargs` thanks to the `prepare_inputs_for_generation` method that automatically takes care of updating the inputs and attention masks in the correct format (should be also compatible with previous versions)

cc @casper-hansen @TheBloke