### PR TITLE
Fix quantization issue with transformers >= 4.36.0

### DIFF
--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -171,14 +171,16 @@ class AwqQuantizer:
 
         # [STEP 3]: Compute output of module
         with torch.no_grad():
-            fp16_output = module2inspect(inp, **kwargs)
+            module_kwargs = self._sanitize_kwargs(kwargs, module2inspect)
+
+            fp16_output = module2inspect(inp, **module_kwargs)
             if isinstance(fp16_output, tuple):
                 fp16_output = fp16_output[0]
         
         # [STEP 4]: Compute loss
         best_scales = self._compute_best_scale(
             inp, w_max, x_max, module2inspect,
-            layers, fp16_output, kwargs
+            layers, fp16_output, module_kwargs
         )
         
         return (get_op_name(module, prev_op), tuple([get_op_name(module, m) for m in layers]), best_scales)

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -395,9 +395,9 @@ class AwqQuantizer:
         # Sanitize the kwargs in case we use transformers version that contains
         # kwargs that are not handled by the module.
         # Useful for trust_remote_code models.
-        self.module_kwargs = self._sanitize_kwargs(self.module_kwargs, layer)
+        module_kwargs = self._sanitize_kwargs(self.module_kwargs, layer)
 
-        self.inps = layer(self.inps, **self.module_kwargs)[0]
+        self.inps = layer(self.inps, **module_kwargs)[0]
         for h in handles:
             h.remove()
         # now solve for scaling and clipping


### PR DESCRIPTION
Fixes https://github.com/casper-hansen/AutoAWQ/issues/260

For some models, mainly models that use code on the Hub feature such as Qwen architecture, some target modules do not properly handle arguments such as `past_key_value`. I need to dig a bit though why this happens only on transformers 4.36.0 but this seems to work fine as a quick hotfix


```python
from awq import AutoAWQForCausalLM
from transformers import AutoTokenizer

model_path = 'Qwen/Qwen-7B-Chat'
quant_path = 'qwen-7b-awq'
quant_config = { "zero_point": True, "q_group_size": 128, "w_bit": 4, "version": "GEMM" }

# Load model
# NOTE: pass safetensors=True to load safetensors
model = AutoAWQForCausalLM.from_pretrained(model_path, **{"low_cpu_mem_usage": True}, safetensors=True)
tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)

# Quantize
model.quantize(tokenizer, quant_config=quant_config)

# Save quantized model
model.save_quantized(quant_path)
tokenizer.save_pretrained(quant_path)

print(f'Model is quantized and saved at "{quant_path}"')
```

cc @casper-hansen 