### PR TITLE
GGUF compatible quantization (2, 3, 4 bit / any bit)

### DIFF
--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -83,12 +83,14 @@ class BaseAWQForCausalLM(nn.Module):
     @torch.no_grad()
     def quantize(self, tokenizer=None, quant_config={},
                        calib_data: Union[str, List[str]]="pileval", 
-                       split="train", text_column="text", duo_scaling=True, modules_to_not_convert=None):
+                       split="train", text_column="text", duo_scaling=True, 
+                       modules_to_not_convert=None, gguf_compatible=False):
         self.quant_config: AwqConfig = AwqConfig.from_dict(quant_config)
 
         quantizer = AwqQuantizer(
             self, self.model, tokenizer, self.quant_config.w_bit, self.quant_config.q_group_size,
-            self.quant_config.version, calib_data, split, text_column, duo_scaling, modules_to_not_convert=modules_to_not_convert
+            self.quant_config.version, calib_data, split, text_column, duo_scaling, modules_to_not_convert=modules_to_not_convert,
+            gguf_compatible=gguf_compatible
         )
         quantizer.quantize()
         

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -22,7 +22,7 @@ from awq.utils.module import (
 class AwqQuantizer:
     def __init__(self, awq_model, model, tokenizer, w_bit, group_size, version, 
                        calib_data, split, text_column, duo_scaling, modules_to_not_convert=None,
-                       gguf_compatible=False) -> None:
+                       export_compatible=False) -> None:
         self.awq_model = awq_model
         self.model = model
         self.tokenizer = tokenizer
@@ -33,7 +33,7 @@ class AwqQuantizer:
         self.split = split
         self.text_column = text_column
         self.duo_scaling = duo_scaling
-        self.gguf_compatible = gguf_compatible
+        self.export_compatible = export_compatible
         self.modules_to_not_convert = modules_to_not_convert if modules_to_not_convert is not None else []
         self.modules, self.module_kwargs, self.inps = self.init_quant()
     
@@ -117,9 +117,16 @@ class AwqQuantizer:
             clip_list = append_str_prefix(clip_list, get_op_name(self.model, self.modules[i]) + ".")
 
             # [STEP 4]: Quantize weights
-            if not self.gguf_compatible:
+            if not self.export_compatible:
                 self._apply_quant(self.modules[i], named_linears)
             
+            clear_memory()
+    
+    def pack(self):
+        for i in tqdm(range(len(self.modules)), desc="Packing"):
+            named_linears = get_named_linears(self.modules[i])
+            named_linears = exclude_layers_to_not_quantize(named_linears, self.modules_to_not_convert)
+            self._apply_quant(self.modules[i], named_linears)
             clear_memory()
     
     def _apply_quant(self, module, named_linears: Dict[str, nn.Linear]):

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -21,7 +21,8 @@ from awq.utils.module import (
 
 class AwqQuantizer:
     def __init__(self, awq_model, model, tokenizer, w_bit, group_size, version, 
-                       calib_data, split, text_column, duo_scaling, modules_to_not_convert=None) -> None:
+                       calib_data, split, text_column, duo_scaling, modules_to_not_convert=None,
+                       gguf_compatible=False) -> None:
         self.awq_model = awq_model
         self.model = model
         self.tokenizer = tokenizer
@@ -32,6 +33,7 @@ class AwqQuantizer:
         self.split = split
         self.text_column = text_column
         self.duo_scaling = duo_scaling
+        self.gguf_compatible = gguf_compatible
         self.modules_to_not_convert = modules_to_not_convert if modules_to_not_convert is not None else []
         self.modules, self.module_kwargs, self.inps = self.init_quant()
     
@@ -109,7 +111,9 @@ class AwqQuantizer:
             clip_list = append_str_prefix(clip_list, get_op_name(self.model, self.modules[i]) + ".")
 
             # [STEP 4]: Quantize weights
-            self._apply_quant(self.modules[i], named_linears)
+            if not self.gguf_compatible:
+                self._apply_quant(self.modules[i], named_linears)
+            
             clear_memory()
     
     def _apply_quant(self, module, named_linears: Dict[str, nn.Linear]):

--- a/examples/awq_to_gguf_quant.py
+++ b/examples/awq_to_gguf_quant.py
@@ -3,10 +3,10 @@ import subprocess
 from awq import AutoAWQForCausalLM
 from transformers import AutoTokenizer
 
-model_path = 'TheBloke/Llama-2-7B-Chat-fp16'
-quant_path = 'llama-2-7b-chat-awq'
+model_path = 'mistralai/Mistral-7B-v0.1'
+quant_path = 'mistral-awq'
 llama_cpp_path = '/workspace/llama.cpp'
-quant_config = { "zero_point": True, "q_group_size": 128, "w_bit": 4, "version": "GEMM" }
+quant_config = { "zero_point": True, "q_group_size": 128, "w_bit": 6, "version": "GEMM" }
 
 # Load model
 # NOTE: pass safetensors=True to load safetensors
@@ -31,7 +31,7 @@ print(f'Model is quantized and saved at "{quant_path}"')
 
 # GGUF conversion
 print('Converting model to GGUF...')
-llama_cpp_method = f"q{quant_config['w_bit']}_0"
+llama_cpp_method = "q4_K_M"
 convert_cmd_path = os.path.join(llama_cpp_path, "convert.py")
 quantize_cmd_path = os.path.join(llama_cpp_path, "quantize")
 

--- a/examples/awq_to_gguf_quant.py
+++ b/examples/awq_to_gguf_quant.py
@@ -4,9 +4,9 @@ from awq import AutoAWQForCausalLM
 from transformers import AutoTokenizer
 
 model_path = 'TheBloke/Llama-2-7B-Chat-fp16'
-quant_path = 'llama-2-7b-3bit-awq'
+quant_path = 'llama-2-7b-chat-awq'
 llama_cpp_path = '/workspace/llama.cpp'
-quant_config = { "zero_point": True, "q_group_size": 128, "w_bit": 3, "version": "GEMM" }
+quant_config = { "zero_point": True, "q_group_size": 128, "w_bit": 4, "version": "GEMM" }
 
 # Load model
 # NOTE: pass safetensors=True to load safetensors
@@ -31,32 +31,18 @@ print(f'Model is quantized and saved at "{quant_path}"')
 
 # GGUF conversion
 print('Converting model to GGUF...')
+llama_cpp_method = f"q{quant_config['w_bit']}_0"
+convert_cmd_path = os.path.join(llama_cpp_path, "convert.py")
+quantize_cmd_path = os.path.join(llama_cpp_path, "quantize")
 
 if not os.path.exists(llama_cpp_path):
-    cmd = f"git clone https://github.com/ggerganov/llama.cpp.git {llama_cpp_path} && cd {llama_cpp_path} && make LLAMA_CUBLAS=1"
+    cmd = f"git clone https://github.com/ggerganov/llama.cpp.git {llama_cpp_path} && cd {llama_cpp_path} && make LLAMA_CUBLAS=1 LLAMA_CUDA_F16=1"
     subprocess.run([cmd], shell=True, check=True)
 
-# Step 1: python convert.py {quant_path} --outfile {quant_path}/model.gguf
-convert_script = "convert.py" if model.model_type == 'llama' else "convert-hf-to-gguf.py"
-convert_cmd_path = os.path.join(llama_cpp_path, convert_script)
 subprocess.run([
     f"python {convert_cmd_path} {quant_path} --outfile {quant_path}/model.gguf"
 ], shell=True, check=True)
 
-# Step 2: ./quantize {quant_path}/model.gguf {quant_path}/model_q3.gguf q3_k
-llama_cpp_method = f"q{quant_config['w_bit']}_k"
-quantize_cmd_path = os.path.join(llama_cpp_path, "quantize")
 subprocess.run([
     f"{quantize_cmd_path} {quant_path}/model.gguf {quant_path}/model_{llama_cpp_method}.gguf {llama_cpp_method}"
 ], shell=True, check=True)
-
-# Step 3: Inference using llama.cpp
-main_cmd_path = os.path.join(llama_cpp_path, "main")
-prompt = "[INST] <<SYS>>You are a helpful, respectful and honest assistant.<</SYS>>Hello![/INST]"
-cmd = f"""{main_cmd_path} \
-  -m {quant_path}/model_{llama_cpp_method}.gguf \
-  -p "{prompt}" \
-  --repeat_penalty 1 \
-  --no-penalize-nl \
-  --color --temp 0 -c 512 --n-gpu-layers 33"""
-subprocess.run([cmd], shell=True, check=True)

--- a/examples/awq_to_gguf_quant.py
+++ b/examples/awq_to_gguf_quant.py
@@ -21,7 +21,7 @@ tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 model.quantize(
     tokenizer,
     quant_config=quant_config,
-    gguf_compatible=True
+    export_compatible=True
 )
 
 # Save quantized model

--- a/examples/awq_to_gguf_quant.py
+++ b/examples/awq_to_gguf_quant.py
@@ -1,0 +1,62 @@
+import os
+import subprocess
+from awq import AutoAWQForCausalLM
+from transformers import AutoTokenizer
+
+model_path = 'TheBloke/Llama-2-7B-Chat-fp16'
+quant_path = 'llama-2-7b-3bit-awq'
+llama_cpp_path = '/workspace/llama.cpp'
+quant_config = { "zero_point": True, "q_group_size": 128, "w_bit": 3, "version": "GEMM" }
+
+# Load model
+# NOTE: pass safetensors=True to load safetensors
+model = AutoAWQForCausalLM.from_pretrained(
+    model_path, **{"low_cpu_mem_usage": True, "use_cache": False}
+)
+tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+
+# Quantize
+# NOTE: We avoid packing weights, so you cannot use this model in AutoAWQ
+# after quantizing. The saved model is FP16 but has the AWQ scales applied.
+model.quantize(
+    tokenizer,
+    quant_config=quant_config,
+    gguf_compatible=True
+)
+
+# Save quantized model
+model.save_quantized(quant_path)
+tokenizer.save_pretrained(quant_path)
+print(f'Model is quantized and saved at "{quant_path}"')
+
+# GGUF conversion
+print('Converting model to GGUF...')
+
+if not os.path.exists(llama_cpp_path):
+    cmd = f"git clone https://github.com/ggerganov/llama.cpp.git {llama_cpp_path} && cd {llama_cpp_path} && make LLAMA_CUBLAS=1"
+    subprocess.run([cmd], shell=True, check=True)
+
+# Step 1: python convert.py {quant_path} --outfile {quant_path}/model.gguf
+convert_script = "convert.py" if model.model_type == 'llama' else "convert-hf-to-gguf.py"
+convert_cmd_path = os.path.join(llama_cpp_path, convert_script)
+subprocess.run([
+    f"python {convert_cmd_path} {quant_path} --outfile {quant_path}/model.gguf"
+], shell=True, check=True)
+
+# Step 2: ./quantize {quant_path}/model.gguf {quant_path}/model_q3.gguf q3_k
+llama_cpp_method = f"q{quant_config['w_bit']}_k"
+quantize_cmd_path = os.path.join(llama_cpp_path, "quantize")
+subprocess.run([
+    f"{quantize_cmd_path} {quant_path}/model.gguf {quant_path}/model_{llama_cpp_method}.gguf {llama_cpp_method}"
+], shell=True, check=True)
+
+# Step 3: Inference using llama.cpp
+main_cmd_path = os.path.join(llama_cpp_path, "main")
+prompt = "[INST] <<SYS>>You are a helpful, respectful and honest assistant.<</SYS>>Hello![/INST]"
+cmd = f"""{main_cmd_path} \
+  -m {quant_path}/model_{llama_cpp_method}.gguf \
+  -p "{prompt}" \
+  --repeat_penalty 1 \
+  --no-penalize-nl \
+  --color --temp 0 -c 512 --n-gpu-layers 33"""
+subprocess.run([cmd], shell=True, check=True)


### PR DESCRIPTION
AWQ has only ever been able to run 4-bit quantization. However, with this integration, we can run any-bit quantization and export to `llama.cpp` for inference. This results in lower perplexity while ensuring compatibility with the GGUF ecosystem.

The difference between GGUF and AWQ is most pronounced on the q<bit>_0 and q<bit>_1 models but I include most perplexity numbers for the K method from llama.cpp since it reaches the lowest perplexity.

### Perplexity

Perplexity measured with: `./perplexity -m <gguf_model> -f wikitext-2-raw/wiki.test.raw -ngl 33`

#### Base Model: Mistral 7B (mistralai/Mistral-7B-v0.1)

FP16: 5.6934

| Method | Perplexity (duo_scaling=True) | Perplexity (duo_scaling=False) |
|---|---|---|
| GGUF Q2_K | 6.1640 +/- 0.03474  | |
| GGUF Q3_K_M |  5.8881 +/- 0.03320 | |
| GGUF Q4_0 |  5.8189 +/- 0.03257 | |
| GGUF Q4_K_M | 5.7518 +/- 0.03231  | |
| AWQ 2-bit + GGUF Q2_K | 6.7290 +/- 0.04008 | |
| AWQ 3-bit + GGUF Q2_K | 6.1079 +/- 0.03482 | 6.1147 +/- 0.03474 |
| AWQ 3-bit + GGUF Q3_K_M | 5.9123 +/- 0.03376 | 5.9072 +/- 0.03362 |
| AWQ 4-bit + GGUF Q3_K_M |  5.8528 +/- 0.03304 | 5.8570 +/- 0.03306 |
| AWQ 4-bit + GGUF Q4_0|  5.8127 +/- 0.03289 | 5.8018 +/- 0.03272 |
| AWQ 4-bit + GGUF Q4_K_M | 5.7415 +/- 0.03237 | 5.7396 +/- 0.03230 |
| AWQ 6-bit + GGUF Q4_0|  5.8064 +/- 0.03261 | 5.8030 +/- 0.03259 |
| AWQ 6-bit + GGUF Q4_K_M | 5.7442 +/- 0.03226 | 5.7425 +/- 0.03226 |

#### Mixture of Experts Model: Mixtral 8x7B (mistralai/Mixtral-8x7B-v0.1)

| Method | Perplexity (duo_scaling=True) |
|---|---|
| GGUF Q2_K | 7.8406 +/- 0.04688 |
| GGUF Q3_K_M | 4.4192 +/- 0.02298  |
| GGUF Q4_0 |  4.2242 +/- 0.02167 |
| GGUF Q4_K_M | 4.2499 +/- 0.02188 |
| AWQ 2-bit + GGUF Q2_K |  |
| AWQ 3-bit + GGUF Q2_K |  |
| AWQ 3-bit + GGUF Q3_K_M |  |
| AWQ 4-bit + GGUF Q3_K_M | 4.4301 +/- 0.02294  |
| AWQ 4-bit + GGUF Q4_0|  4.2696 +/- 0.02182 |
| AWQ 4-bit + GGUF Q4_K_M | 4.2239 +/- 0.02158 |
| AWQ 6-bit + GGUF Q4_0|   |
| AWQ 6-bit + GGUF Q4_K_M |  |

#### Chat Model: Llama 2 7B Chat (TheBloke/Llama-2-7B-Chat-fp16)

| Method | Perplexity |
|---|---|
| GGUF Q2_K |  8.5820 +/- 0.05855 |
| GGUF Q3_K_M |  7.8605 +/- 0.05264 |
| GGUF Q4_0 |  7.8797 +/- 0.05373 |
| GGUF Q4_K_M | 7.7172 +/- 0.05209  |
| AWQ 3-bit + GGUF Q2_K | 8.6528 +/- 0.05887  |
| AWQ 3-bit + GGUF Q3_K_M |  7.9620 +/- 0.05289 |
| AWQ 4-bit + GGUF Q3_K_M |  7.8312 +/- 0.05226 |
| AWQ 4-bit + GGUF Q4_0|  7.8115 +/- 0.05293 |
| AWQ 4-bit + GGUF Q4_K_M | 7.7438 +/- 0.05220 |
| AWQ 6-bit + GGUF Q4_K_M | 7.7372 +/- 0.05234 |
