### PR TITLE
Add CPU-loaded multi-GPU quantization

### DIFF
--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -81,9 +81,11 @@ class AwqQuantizer:
             # Move module and inputs to correct device
             common_device = next(self.modules[i].parameters()).device
             if common_device is None or str(common_device) == "cpu":
-                self.modules[i] = self.modules[i].cuda()
+                self.modules[i] = self.modules[i].cuda("cuda:" + str(i % torch.cuda.device_count()))
                 common_device = next(self.modules[i].parameters()).device
             
+            self.module_kwargs["position_ids"] = self.module_kwargs["position_ids"].to(common_device)
+            self.module_kwargs["attention_mask"] = self.module_kwargs["attention_mask"].to(common_device)
             self.inps = self.inps.to(common_device)
 
             # [STEP 1]: Get layer, extract linear modules, extract input features

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -83,9 +83,13 @@ class AwqQuantizer:
             if common_device is None or str(common_device) == "cpu":
                 self.modules[i] = self.modules[i].cuda("cuda:" + str(i % torch.cuda.device_count()))
                 common_device = next(self.modules[i].parameters()).device
-            
-            self.module_kwargs["position_ids"] = self.module_kwargs["position_ids"].to(common_device)
-            self.module_kwargs["attention_mask"] = self.module_kwargs["attention_mask"].to(common_device)
+
+            if self.module_kwargs.get("position_ids") is not None:
+                self.module_kwargs["position_ids"] = self.module_kwargs["position_ids"].to(common_device)
+
+            if self.module_kwargs.get("attention_mask") is not None:
+                self.module_kwargs["attention_mask"] = self.module_kwargs["attention_mask"].to(common_device)
+
             self.inps = self.inps.to(common_device)
 
             # [STEP 1]: Get layer, extract linear modules, extract input features


### PR DESCRIPTION
GPU memory is very valuable. Usually, users don't have a lot of it and so they turn to techniques like quantization to run the models they want with their limited amount of GPU memory. However, quantizing those models uses a lot of GPU memory as well.

Aside from full CPU-based quantization, the best technique I've discovered for quantizing models while limiting GPU memory is to load the model into CPU memory and offload those layers into GPU memory one at a time. AutoAWQ allows for this, but only supports using one GPU for the entire quantization process which limits the amount of GPU memory one can utilize to a single GPU's worth.

Here, I've added a few lines of code which allow models loaded in CPU memory which are offloaded to a GPU for quantization, to be offloaded to all GPUs instead. Layers are automatically distributed across all GPUs on the system via a simple algorithm and all GPUs are utilized in the quantization process.

Thanks to this change, I was able to quantize Mixtral 8x7b on my own system of 4x24GB GPUs. Loading the model with `device_map` across all GPUs worked, but quantizing the model in addition to that resulted in a CUDA OOM error. Loading the model with `device_map` on the CPU also worked, but quantizing the model would offload it to a single 24GB GPU which would only make it through half of the quantization process before CUDA OOM'ing. Loading the model with `device_map` on the CPU and quantizing the model with these changes, offloads the model to all four of my 24GB GPUs and succeeds in quantizing the model.

Model layers are of different sizes and so this simple algorithm is a naive one that can certainly be optimized further to make efficient use of the user's GPU memory. Perhaps this can be done in the future. Additionally, I think one could parallelize the quantization of the CPU-loaded models with this technique and see great performance improvements.