### PR TITLE
Add Codeshell Support

### DIFF
--- a/awq/models/__init__.py
+++ b/awq/models/__init__.py
@@ -13,3 +13,4 @@ from .qwen import QwenAWQForCausalLM
 from .baichuan import BaichuanAWQForCausalLM
 from .llava import LlavaAWQForCausalLM
 from .mixtral import MixtralAWQForCausalLM
+from .codeshell import CodeShellAWQForCausalLM

--- a/awq/models/auto.py
+++ b/awq/models/auto.py
@@ -21,6 +21,7 @@ AWQ_CAUSAL_LM_MODEL_MAP = {
     "qwen": QwenAWQForCausalLM,
     "baichuan": BaichuanAWQForCausalLM,
     "llava": LlavaAWQForCausalLM,
+    "codeshell": CodeShellAWQForCausalLM,
 }
 
 def check_and_get_model_type(model_dir, trust_remote_code=True, **model_init_kwargs):

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -57,6 +57,7 @@ TRANSFORMERS_AUTO_MAPPING_DICT = {
     "qwen": "AutoModelForCausalLM",
     "baichuan": "AutoModelForCausalLM",
     "llava": "AutoModelForVision2Seq",
+    "codeshell": "AutoModelForCausalLM",
 }
 
 class BaseAWQForCausalLM(nn.Module):

--- a/awq/models/codeshell.py
+++ b/awq/models/codeshell.py
@@ -1,0 +1,51 @@
+from .base import BaseAWQForCausalLM
+
+class CodeShellAWQForCausalLM(BaseAWQForCausalLM):
+    layer_type = "CodeShellBlock"
+    max_new_tokens_key = "n_positions"
+
+    @staticmethod
+    def get_model_layers(model):
+        return model.transformer.h
+
+    @staticmethod
+    def get_act_for_scaling(module):
+        return dict(
+            is_scalable=True,
+            scale_name="mlp.act",
+            scale_layer=module.mlp.act,
+            scale_shape=module.mlp.c_fc.out_features
+        )
+
+    @staticmethod
+    def move_embed(model, device: str):
+        model.transformer.wte = model.transformer.wte.to(device)
+
+
+    @staticmethod
+    def get_layers_for_scaling(module, input_feat, module_kwargs):
+        layers = []
+        # attention
+        layers.append(
+            dict(
+                prev_op=module.ln_1,
+                layers=[module.attn.c_attn],
+                inp=input_feat['attn.c_attn'],
+            )
+        )
+        # mlp
+        layers.append(
+            dict(
+                prev_op=module.ln_2,
+                layers=[module.mlp.c_fc],
+                inp=input_feat['mlp.c_fc']
+            )
+        )
+        layers.append(
+            dict(
+                prev_op=module.mlp.act,
+                layers=[module.mlp.c_proj],
+                inp=input_feat['mlp.c_proj']
+            )
+        )
+        return layers


### PR DESCRIPTION
**hugging face model card**: WisdomShell/CodeShell-7B-Chat

**Model Description**: CodeShell is a multi-language code LLM developed by the [Knowledge Computing Lab](http://se.pku.edu.cn/kcl/) of Peking University. CodeShell has 7 billion parameters and was trained on 500 billion tokens with a context window length of 8194. On authoritative code evaluation benchmarks (HumanEval and MBPP), CodeShell achieves the best performance of its scale. Meanwhile, we provide deployment solutions and IDE plugins that complement CodeShell. Please refer to the [CodeShell code repository](https://github.com/WisdomShell/codeshell) for more details. This repository is for the CodeShell-7B-Chat model.

Although Codeshell supports 4-bit BitsandBytes quantization, I still want to run Codeshell using AWQ's method. In real-world tests, AWQ has shown higher performance compared to BitsandBytes.

Specifically, in WisdomShell/CodeShell-7B, the model failed to load due to the 'model_type' being configured as 'kclgpt' in the model.config, whereas the actual 'model_type' is 'codeshell'. This was due to an error made by the uploader.

![image](https://github.com/casper-hansen/AutoAWQ/assets/53092165/9b5ed9f6-a000-4404-b94c-e42f3cfef0a2)



