### PR TITLE
Mixtral scaling: Reduce perplexity from 4.294 to 4.269

### DIFF
--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -315,7 +315,7 @@ class BaseAWQForCausalLM(nn.Module):
                 set_op_by_name(layer, scale_dict['scale_name'], scaled_act)
 
     def _scale_moe(self, layer):
-        if hasattr(self, "get_moe_for_scaling"):
+        if hasattr(self, "get_moe_for_scaling") and hasattr(layer.block_sparse_moe, "scales"):
             scale_dict: dict = self.get_moe_for_scaling(layer)
 
             if not isinstance(scale_dict['scale_layer'], ScaledMixtralSparseMoeBlock):

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -316,7 +316,7 @@ class BaseAWQForCausalLM(nn.Module):
 
     def _scale_moe(self, layer):
         if hasattr(self, "get_moe_for_scaling"):
-            scale_dict: dict = self.get_moe_for_scaling()
+            scale_dict: dict = self.get_moe_for_scaling(layer)
 
             if not isinstance(scale_dict['scale_layer'], ScaledMixtralSparseMoeBlock):
                 param = next(layer.parameters())

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -84,12 +84,16 @@ class BaseAWQForCausalLM(nn.Module):
     @torch.no_grad()
     def quantize(self, tokenizer=None, quant_config={},
                        calib_data: Union[str, List[str]]="pileval", 
-                       split="train", text_column="text", duo_scaling=True, modules_to_not_convert=None):
+                       split="train", text_column="text", duo_scaling=True):
         self.quant_config: AwqConfig = AwqConfig.from_dict(quant_config)
+
+        if hasattr(self, "modules_to_not_convert"):
+            self.quant_config.modules_to_not_convert = self.modules_to_not_convert
 
         quantizer = AwqQuantizer(
             self, self.model, tokenizer, self.quant_config.w_bit, self.quant_config.q_group_size,
-            self.quant_config.version, calib_data, split, text_column, duo_scaling, modules_to_not_convert=modules_to_not_convert
+            self.quant_config.version, calib_data, split, text_column, duo_scaling,
+            modules_to_not_convert=self.quant_config.modules_to_not_convert
         )
         quantizer.quantize()
         

--- a/awq/models/mixtral.py
+++ b/awq/models/mixtral.py
@@ -20,7 +20,7 @@ def _transformers_version_check():
     else:
         major, minor, patch = tv
     
-    if int(major) >= 4 and int(minor) < 37:
+    if int(major) == 4 and int(minor) < 37:
         raise Exception("Mixtral requires a minimum of 4.37.0.dev0: pip install git+https://github.com/huggingface/transformers.git")
 
 class MixtralAWQForCausalLM(BaseAWQForCausalLM):

--- a/awq/models/mixtral.py
+++ b/awq/models/mixtral.py
@@ -31,6 +31,14 @@ class MixtralAWQForCausalLM(BaseAWQForCausalLM):
         )
     
     @staticmethod
+    def get_moe_for_scaling(module: OldMixtralDecoderLayer):
+        return dict(
+            scale_name="block_sparse_moe",
+            scale_layer=module.block_sparse_moe,
+            scale_shape=(module.block_sparse_moe.num_experts, module.block_sparse_moe.hidden_dim),
+        )
+    
+    @staticmethod
     def move_embed(model: OldMixtralForCausalLM, device: str):
         model.model.embed_tokens = model.model.embed_tokens.to(device)
     

--- a/awq/models/mixtral.py
+++ b/awq/models/mixtral.py
@@ -75,16 +75,6 @@ class MixtralAWQForCausalLM(BaseAWQForCausalLM):
                 layers=[module.self_attn.o_proj],
                 inp=input_feat['self_attn.o_proj'],
             ))
-        
-        layers.append(dict(
-            prev_op=module.post_attention_layernorm,
-            layers=[
-                w for expert in module.block_sparse_moe.experts
-                  for w in [expert.w1, expert.w3]
-            ],
-            inp=input_feat['block_sparse_moe'],
-            module2inspect=module.block_sparse_moe,
-        ))
 
         # NOTE: Scaled in awq.quantize.scale.scale_moe_experts, awq.modules.moe.ScaledMixtralSparseMoeBlock
         # Experts: Not a linear layer, special handling is introduced in awq.quantize.quantizer

--- a/awq/models/mixtral.py
+++ b/awq/models/mixtral.py
@@ -26,6 +26,7 @@ def _transformers_version_check():
 class MixtralAWQForCausalLM(BaseAWQForCausalLM):
     layer_type = "MixtralDecoderLayer"
     max_new_tokens_key = "max_position_embeddings"
+    modules_to_not_convert = ["gate"]
     
     @staticmethod
     def fuse_layers(model: OldMixtralForCausalLM):

--- a/awq/models/mixtral.py
+++ b/awq/models/mixtral.py
@@ -12,6 +12,17 @@ from transformers.models.mixtral.modeling_mixtral import (
 from awq.modules.fused.mlp import QuantFusedMLP
 from awq.modules.fused.norm import FasterTransformerRMSNorm
 
+def _transformers_version_check():
+    import transformers
+    tv = transformers.__version__.split('.')
+    if len(tv) == 4:
+        major, minor, patch, dev = tv
+    else:
+        major, minor, patch = tv
+    
+    if int(major) >= 4 and int(minor) < 37:
+        raise Exception("Mixtral requires a minimum of 4.37.0.dev0: pip install git+https://github.com/huggingface/transformers.git")
+
 class MixtralAWQForCausalLM(BaseAWQForCausalLM):
     layer_type = "MixtralDecoderLayer"
     max_new_tokens_key = "max_position_embeddings"
@@ -23,6 +34,7 @@ class MixtralAWQForCausalLM(BaseAWQForCausalLM):
     
     @staticmethod
     def get_model_layers(model: OldMixtralForCausalLM):
+        _transformers_version_check()
         return model.model.layers
     
     @staticmethod

--- a/awq/models/mixtral.py
+++ b/awq/models/mixtral.py
@@ -63,6 +63,16 @@ class MixtralAWQForCausalLM(BaseAWQForCausalLM):
                 layers=[module.self_attn.o_proj],
                 inp=input_feat['self_attn.o_proj'],
             ))
+        
+        layers.append(dict(
+            prev_op=module.post_attention_layernorm,
+            layers=[
+                w for expert in module.block_sparse_moe.experts
+                  for w in [expert.w1, expert.w3]
+            ],
+            inp=input_feat['block_sparse_moe'],
+            module2inspect=module.block_sparse_moe,
+        ))
 
         # NOTE: Scaled in awq.quantize.scale.scale_moe_experts, awq.modules.moe.ScaledMixtralSparseMoeBlock
         # Experts: Not a linear layer, special handling is introduced in awq.quantize.quantizer

--- a/awq/modules/moe.py
+++ b/awq/modules/moe.py
@@ -1,0 +1,90 @@
+import torch
+
+from transformers.models.mixtral.configuration_mixtral import MixtralConfig
+from transformers.models.mixtral.modeling_mixtral import MixtralSparseMoeBlock
+
+class ScaledMixtralSparseMoeBlock(torch.nn.Module):
+    """
+    This is a modified sparse MoE that scales experts individually.
+
+    Modified version of:
+    transformers.models.mixtral.modeling_mixtral.MixtralSparseMoeBlock
+    """
+
+    def __init__(self, prev_op: MixtralSparseMoeBlock, scales: torch.Tensor):
+        super().__init__()
+        config: MixtralConfig = prev_op.config
+        self.hidden_dim = config.hidden_size
+        self.ffn_dim = config.intermediate_size
+        self.num_experts = config.num_local_experts
+        self.top_k = config.num_experts_per_tok
+
+        # gating
+        self.gate = torch.nn.Linear(self.hidden_dim, self.num_experts, bias=False)
+        self.experts = torch.nn.ModuleList([MixtralBLockSparseTop2MLP(config) for _ in range(self.num_experts)])
+
+        # [expert_num, hidden_dim]
+        self.scales = torch.nn.Parameter(scales.data)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """ """
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+        # router_logits: (batch * sequence_length, n_experts)
+        router_logits = self.gate(hidden_states)
+
+        routing_weights = torch.nn.functional.softmax(router_logits, dim=1, dtype=torch.float)
+        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+        # we cast back to the input dtype
+        routing_weights = routing_weights.to(hidden_states.dtype)
+
+        final_hidden_states = torch.zeros(
+            (batch_size * sequence_length, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
+        )
+
+        # One hot encode the selected experts to create an expert mask
+        # this will be used to easily index which expert is going to be sollicitated
+        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+
+        # Loop over all available experts in the model and perform the computation on each expert
+        for expert_idx in range(self.num_experts):
+            expert_layer = self.experts[expert_idx]
+            idx, top_x = torch.where(expert_mask[expert_idx])
+
+            if top_x.shape[0] == 0:
+                continue
+
+            # in torch it is faster to index using lists than torch tensors
+            top_x_list = top_x.tolist()
+            idx_list = idx.tolist()
+
+            # Index the correct hidden states and compute the expert hidden state for
+            # the current expert. We need to make sure to multiply the output hidden
+            # states by `routing_weights` on the corresponding tokens (top-1 and top-2)
+            ### MODIFICATION START
+            current_state = hidden_states[None, top_x_list].reshape(-1, hidden_dim) / self.scales[expert_idx]
+            ### MODIFICATION END
+            current_hidden_states = expert_layer(current_state) * routing_weights[top_x_list, idx_list, None]
+
+            # However `index_add_` only support torch tensors for indexing so we'll use
+            # the `top_x` tensor here.
+            final_hidden_states.index_add_(0, top_x, current_hidden_states.to(hidden_states.dtype))
+        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+        return final_hidden_states, router_logits
+
+class MixtralBLockSparseTop2MLP(torch.nn.Module):
+    def __init__(self, config: MixtralConfig):
+        super().__init__()
+        self.ffn_dim = config.intermediate_size
+        self.hidden_dim = config.hidden_size
+
+        self.w1 = torch.nn.Linear(self.hidden_dim, self.ffn_dim, bias=False)
+        self.w2 = torch.nn.Linear(self.ffn_dim, self.hidden_dim, bias=False)
+        self.w3 = torch.nn.Linear(self.hidden_dim, self.ffn_dim, bias=False)
+        self.act_fn = torch.nn.SiLU
+
+    def forward(self, hidden_states):
+        current_hidden_states = self.act_fn(self.w1(hidden_states)) * self.w3(hidden_states)
+        current_hidden_states = self.w2(current_hidden_states)
+        return current_hidden_states

--- a/awq/modules/moe.py
+++ b/awq/modules/moe.py
@@ -68,7 +68,7 @@ class ScaledMixtralSparseMoeBlock(torch.nn.Module):
             
             ### NOTE: We scale weights here, modified from original MoE.
             current_state = hidden_states[None, top_x_list].reshape(-1, hidden_dim) / self.scales[expert_idx]
-            current_hidden_states = expert_layer(current_state) * routing_weights[top_x_list, idx_list, None]
+            current_hidden_states = expert_layer(expert_layer, current_state) * routing_weights[top_x_list, idx_list, None]
 
             # However `index_add_` only support torch tensors for indexing so we'll use
             # the `top_x` tensor here.

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -4,9 +4,10 @@ import logging
 import functools
 import torch.nn as nn
 from tqdm import tqdm
-from typing import Dict, List, Union
 from collections import defaultdict
+from typing import Dict, List, Union
 from awq.utils.utils import clear_memory
+from transformers import PreTrainedModel
 from awq.utils.calib_data import get_calib_dataset
 from awq.quantize.scale import apply_scale, apply_clip
 from awq.modules.linear import WQLinear_GEMM, WQLinear_GEMV
@@ -24,7 +25,7 @@ class AwqQuantizer:
     def __init__(self, awq_model, model, tokenizer, w_bit, group_size, version, 
                        calib_data, split, text_column, duo_scaling, modules_to_not_convert=None) -> None:
         self.awq_model = awq_model
-        self.model = model
+        self.model: PreTrainedModel = model
         self.tokenizer = tokenizer
         self.w_bit = w_bit
         self.group_size = group_size

--- a/awq/quantize/scale.py
+++ b/awq/quantize/scale.py
@@ -37,7 +37,12 @@ def apply_scale(module, scales_list, input_feat_dict=None):
         prev_op.cuda()
         for layer in layers:
             layer.cuda()
-        scales.cuda()
+        
+        if type(scales) == list:
+            for scale in scales:
+                scale.cuda()
+        else:
+            scales.cuda()
         
         if isinstance(prev_op, nn.Linear) and type(layers) == list and isinstance(layers[0], nn.Linear):
             scale_fc_fcs(prev_op, layers, scales)
@@ -57,7 +62,7 @@ def apply_scale(module, scales_list, input_feat_dict=None):
         
         elif any(isinstance(prev_op,t) for t in allowed_moe):
             # scales: [best_scale_expert_0, best_scale_expert_1, ...] -> [expert_index, scales]
-            scales = torch.stack(scales)
+            scales = torch.stack(scales).cuda()
 
             # apply scales
             new_module = ScaledMixtralSparseMoeBlock(prev_op, scales)
@@ -79,7 +84,12 @@ def apply_scale(module, scales_list, input_feat_dict=None):
         prev_op.cpu()
         for layer in layers:
             layer.cpu()
-        scales.cpu()
+        
+        if type(scales) == list:
+            for scale in scales:
+                scale.cpu()
+        else:
+            scales.cpu()
 
 @torch.no_grad()
 def scale_ln_fcs(ln: nn.Linear, fcs: List[nn.Linear], scales: torch.Tensor):

--- a/awq/quantize/scale.py
+++ b/awq/quantize/scale.py
@@ -2,13 +2,16 @@ import torch
 import torch.nn as nn
 from typing import Tuple, List
 from awq.modules.act import ScaledActivation
+from awq.modules.moe import ScaledMixtralSparseMoeBlock
 from awq.utils.module import get_op_by_name, set_op_by_name
 from transformers.models.bloom.modeling_bloom import BloomGelu
 from transformers.models.llama.modeling_llama import LlamaRMSNorm
+from transformers.models.mixtral.modeling_mixtral import MixtralSparseMoeBlock
 from transformers.activations import NewGELUActivation, PytorchGELUTanh, GELUActivation
 
 allowed_norms = [nn.LayerNorm, LlamaRMSNorm]
 allowed_act_fns = [nn.GELU, BloomGelu, NewGELUActivation, PytorchGELUTanh, GELUActivation]
+allowed_moes = [MixtralSparseMoeBlock]
 
 @torch.no_grad()
 def apply_clip(module, clip_list: Tuple[str, torch.Tensor]):
@@ -48,6 +51,11 @@ def apply_scale(module, scales_list, input_feat_dict=None):
             new_module = ScaledActivation(prev_op, scales)
             set_op_by_name(module, prev_op_name, new_module)
             scale_gelu_fc(prev_op, layers[0], scales)
+        
+        elif any(isinstance(prev_op,t) for t in allowed_moes):
+            new_module = ScaledMixtralSparseMoeBlock(prev_op, scales)
+            set_op_by_name(module, prev_op_name, new_module)
+            scale_moe_experts(prev_op, layers, scales)
             
         else:
             raise NotImplementedError(
@@ -133,3 +141,15 @@ def scale_gelu_fc(gelu: allowed_act_fns, fc: nn.Linear, scales: torch.Tensor):
 
     for p in fc.parameters():
         assert torch.isnan(p).sum() == 0
+
+@torch.no_grad()
+def scale_moe_experts(moe, experts: List[nn.Linear], scales: torch.Tensor):
+    assert any(isinstance(moe,m) for m in allowed_moes)
+    assert all(isinstance(m, nn.Linear) for m in experts)
+
+    for expert in experts:
+        expert.weight.mul_(scales.view(1, -1))
+    
+    for expert in experts:
+        for p in expert.parameters():
+            assert torch.isnan(p).sum() == 0

--- a/examples/mixtral_quant.py
+++ b/examples/mixtral_quant.py
@@ -3,11 +3,7 @@ from transformers import AutoTokenizer
 
 model_path = 'mistralai/Mixtral-8x7B-Instruct-v0.1'
 quant_path = 'mixtral-instruct-awq'
-modules_to_not_convert = ["gate"]
-quant_config = {
-    "zero_point": True, "q_group_size": 128, "w_bit": 4, "version": "GEMM",
-    "modules_to_not_convert": modules_to_not_convert
-}
+quant_config = {"zero_point": True, "q_group_size": 128, "w_bit": 4, "version": "GEMM"}
 
 # Load model
 # NOTE: pass safetensors=True to load safetensors
@@ -19,8 +15,7 @@ tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 # Quantize
 model.quantize(
     tokenizer,
-    quant_config=quant_config,
-    modules_to_not_convert=modules_to_not_convert
+    quant_config=quant_config
 )
 
 # Save quantized model


### PR DESCRIPTION
This PR reduces the perplexity of Mixtral by introducing scaling of individual experts instead of one scale for all the experts in the MoE block.

To use this in vLLM, GGUF, or other integrations, their code needs to be updated to load the new ScaledMixtralSparseMoeBlock. The only modification needed in the inference code is [right before the experts get the `current_hidden_states`](https://github.com/huggingface/transformers/blob/4ab5fb8941a38d172b3883c152c34ae2a0b83a68/src/transformers/models/mixtral/modeling_mixtral.py#L837):

```python
current_state = hidden_states[None, top_x_list].reshape(
    -1, hidden_dim) / self.scales[expert_idx] # <-- scales
```

Idea by @Sakits, engineering & implementation by @casper-hansen 