### PR TITLE
Add requests and zstandards package as deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,8 @@ requirements = [
     "tokenizers>=0.12.1",
     "accelerate",
     "datasets",
+    "zstandard",
+    "requests",
 ]
 
 try:


### PR DESCRIPTION
To run some quantization examples, we need `requests` and `zstandard` packages.

This error comes when I am running the [quantization example listed in the README.md](https://github.com/casper-hansen/AutoAWQ?tab=readme-ov-file#examples).

Adding both these packages here in this PR.

<details><summary>zstandard import error</summary>
<p>

Specifically on the step where I would like quantization to begin as this -



```
    model.quantize(tokenizer, quant_config=quantization_config)
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/ubuntu/AutoAWQ/awq/models/base.py", line 102, in quantize
    self.quantizer = AwqQuantizer(
  File "/home/ubuntu/AutoAWQ/awq/quantize/quantizer.py", line 56, in __init__
    self.modules, self.module_kwargs, self.inps = self.init_quant()
  File "/home/ubuntu/AutoAWQ/awq/quantize/quantizer.py", line 423, in init_quant
    samples = get_calib_dataset(
  File "/home/ubuntu/AutoAWQ/awq/utils/calib_data.py", line 11, in get_calib_dataset
    dataset = load_dataset("mit-han-lab/pile-val-backup", split="validation")
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/load.py", line 2549, in load_dataset
    builder_instance.download_and_prepare(
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/builder.py", line 1005, in download_and_prepare
    self._download_and_prepare(
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/builder.py", line 1078, in _download_and_prepare
    split_generators = self._split_generators(dl_manager, **split_generators_kwargs)
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/packaged_modules/json/json.py", line 51, in _split_generators
    data_files = dl_manager.download_and_extract(self.config.data_files)
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/download/download_manager.py", line 562, in download_and_extract
    return self.extract(self.download(url_or_urls))
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/download/download_manager.py", line 535, in extract
    extracted_paths = map_nested(
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/utils/py_utils.py", line 466, in map_nested
    mapped = [
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/utils/py_utils.py", line 467, in <listcomp>
    _single_map_nested((function, obj, types, None, True, None))
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/utils/py_utils.py", line 387, in _single_map_nested
    mapped = [_single_map_nested((function, v, types, None, True, None)) for v in pbar]
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/utils/py_utils.py", line 387, in <listcomp>
    mapped = [_single_map_nested((function, v, types, None, True, None)) for v in pbar]
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/utils/py_utils.py", line 370, in _single_map_nested
    return function(data_struct)
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/download/download_manager.py", line 451, in _download
    out = cached_path(url_or_filename, download_config=download_config)
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/utils/file_utils.py", line 217, in cached_path
    output_path = ExtractManager(cache_dir=download_config.cache_dir).extract(
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/utils/extract.py", line 48, in extract
    self.extractor.extract(input_path, output_path, extractor_format)
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/utils/extract.py", line 344, in extract
    return extractor.extract(input_path, output_path)
  File "/home/ubuntu/.conda/envs/awq310/lib/python3.10/site-packages/datasets/utils/extract.py", line 225, in extract
    raise ImportError("Please pip install zstandard")
ImportError: Please pip install zstandard

```

</p>
</details> 