### PR TITLE
New optimized kernels

### DIFF
--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -12,11 +12,17 @@ from typing_extensions import Doc, Annotated
 from huggingface_hub import snapshot_download
 from transformers.modeling_utils import shard_checkpoint
 
-from awq.modules.linear.gemm import WQLinear_GEMM
-from awq.modules.linear.gemv import WQLinear_GEMV
-from awq.modules.linear.marlin import WQLinear_Marlin, marlin_post_init
-from awq.modules.linear.exllama import WQLinear_Exllama, exllama_post_init
-from awq.modules.linear.exllamav2 import WQLinear_ExllamaV2, exllamav2_post_init
+from awq.modules.linear import (
+    WQLinear_GEMM,
+    WQLinear_GEMV,
+    WQLinear_Marlin,
+    WQLinear_Exllama,
+    WQLinear_ExllamaV2,
+    WQLinear_GEMVFast,
+    marlin_post_init,
+    exllama_post_init,
+    exllamav2_post_init,
+)
 from awq.utils.module import (
     get_named_linears,
     set_op_by_name,
@@ -541,6 +547,8 @@ class BaseAWQForCausalLM(nn.Module):
                     q_linear_module = WQLinear_GEMM
                 elif version == "gemv":
                     q_linear_module = WQLinear_GEMV
+                elif version == "gemv_fast":
+                    q_linear_module = WQLinear_GEMVFast
 
                 q_linear = q_linear_module.from_linear(
                     module, quant_config.w_bit, quant_config.q_group_size, True

--- a/awq/modules/linear/__init__.py
+++ b/awq/modules/linear/__init__.py
@@ -1,5 +1,6 @@
-from .exllama import WQLinear_Exllama
-from .exllamav2 import WQLinear_ExllamaV2
+from .exllama import WQLinear_Exllama, exllama_post_init
+from .exllamav2 import WQLinear_ExllamaV2, exllamav2_post_init
 from .gemm import WQLinear_GEMM
 from .gemv import WQLinear_GEMV
-from .marlin import WQLinear_Marlin
+from .marlin import WQLinear_Marlin, marlin_post_init
+from .gemv_fast import WQLinear_GEMVFast

--- a/awq/modules/linear/gemv_fast.py
+++ b/awq/modules/linear/gemv_fast.py
@@ -190,7 +190,7 @@ class WQLinear_GEMVFast(torch.nn.Module):
     def forward(self, x):
         inputs = x
         if inputs.numel() / inputs.shape[-1] < 8:
-            out = awq_v2_ext.gemv_forward_cuda_new(
+            out = awq_v2_ext.gemv_forward_cuda_decode(
                 inputs,
                 self.qweight,
                 self.scales,
@@ -201,7 +201,7 @@ class WQLinear_GEMVFast(torch.nn.Module):
                 self.group_size,
             )
         else:
-            out = awq_v2_ext.gemm_forward_cuda_new(
+            out = awq_v2_ext.gemm_forward_cuda_prefill(
                 inputs, self.qweight, self.scales, self.qzeros
             )
         out = out + self.bias if self.bias is not None else out

--- a/awq/modules/linear/gemv_fast.py
+++ b/awq/modules/linear/gemv_fast.py
@@ -69,7 +69,7 @@ def pack_intweight(unpacked_qweight, interleave, kstride):
     return qweight
 
 
-class WQLinear(torch.nn.Module):
+class WQLinear_GEMVFast(torch.nn.Module):
     def __init__(self, w_bit, group_size, in_features, out_features, bias, dev):
         super().__init__()
 

--- a/awq/modules/linear/gemv_fast.py
+++ b/awq/modules/linear/gemv_fast.py
@@ -1,0 +1,209 @@
+import torch
+
+try:
+    import awq_v2_ext  # with CUDA kernels (AutoAWQ_kernels)
+
+    AWQ_INSTALLED = True
+except:
+    AWQ_INSTALLED = False
+
+
+def make_divisible(c, divisor):
+    return (c + divisor - 1) // divisor
+
+
+def calculate_zeros_width(in_features, group_size=128, pack_num=8):
+    if group_size >= 128:
+        size_multiplier = 1
+    elif group_size == 64:
+        size_multiplier = 2
+    elif group_size == 32:
+        size_multiplier = 4
+    else:
+        raise NotImplementedError
+
+    base_width = make_divisible(in_features // group_size, pack_num)
+    base_width = make_divisible(base_width, size_multiplier) * size_multiplier
+    return base_width
+
+
+def pack_intweight(unpacked_qweight, interleave, kstride):
+    # unpacked_qweight: [N, K]
+    N = unpacked_qweight.shape[0]
+    K = unpacked_qweight.shape[1]
+
+    Packed_Kernel = unpacked_qweight.cpu().numpy().reshape(N, K // 32, 32)
+    # np.arange(32).reshape(4, 4, 2).transpose(1, 0, 2) => [0, 1, 8, 9, 16, 17, 24, 25, ...]
+    Packed_Kernel = Packed_Kernel.reshape(N, K // 32, 4, 4, 2).transpose(0, 1, 3, 2, 4)
+    Packed_Kernel = Packed_Kernel.reshape(N, K // 32, 32)
+
+    # reorder each 8 weights for fast dequantization
+    # [0, 1, 2, 3, 4, 5, 6, 7] => [0, 2, 4, 6, 1, 3, 5, 7]
+    Packed_Kernel = Packed_Kernel.reshape(N, K // 32, 4, 8)
+    Packed_Kernel = Packed_Kernel.reshape(N, K // 32, 4, 4, 2).transpose(0, 1, 2, 4, 3)
+    Packed_Kernel = Packed_Kernel.reshape(N, K)
+
+    # interleaving every four rows
+    Packed_Kernel = Packed_Kernel.reshape(
+        N // interleave, interleave, K // kstride, kstride
+    )
+    # N // 4, K // 64, 4, 64
+    Packed_Kernel = Packed_Kernel.transpose(0, 2, 1, 3)
+    Packed_Kernel = Packed_Kernel.reshape(
+        N // interleave, K // kstride, kstride, interleave
+    )
+    # Packing -> (N // 4, K // 64, 64)
+    Packed_Kernel = (
+        Packed_Kernel[..., 0]
+        | (Packed_Kernel[..., 1] << 4)
+        | (Packed_Kernel[..., 2] << 8)
+        | (Packed_Kernel[..., 3] << 12)
+    )
+    # reshape to (N // 4, K), FP16 format
+    Packed_Kernel = Packed_Kernel.reshape(N // interleave, K)
+    qweight = (
+        torch.tensor(Packed_Kernel.astype("int16"))
+        .to(unpacked_qweight.device)
+        .contiguous()
+    )
+    return qweight
+
+
+class WQLinear(torch.nn.Module):
+    def __init__(self, w_bit, group_size, in_features, out_features, bias, dev):
+        super().__init__()
+
+        self.in_features = in_features
+        self.out_features = out_features
+        self.w_bit = w_bit
+        self.group_size = group_size if group_size != -1 else in_features
+        self.split_k_iters = 8
+        self.interleave = 4
+
+        # quick sanity check (make sure aligment)
+        assert self.in_features % self.group_size == 0
+        assert out_features % (32 // self.w_bit) == 0
+        pack_num = 32 // self.w_bit
+        int16_pack_num = 16 // self.w_bit
+
+        assert out_features % (self.interleave) == 0
+        self.register_buffer(
+            "qweight",
+            torch.zeros(
+                (
+                    out_features // self.interleave,
+                    in_features // int16_pack_num * self.interleave,
+                ),
+                dtype=torch.int16,
+                device=dev,
+            ),
+        )
+        self.register_buffer(
+            "scales",
+            torch.zeros(
+                (
+                    calculate_zeros_width(in_features, self.group_size) * pack_num,
+                    out_features,
+                ),
+                dtype=torch.float16,
+                device=dev,
+            ),
+        )
+        self.register_buffer(
+            "scaled_zeros",
+            torch.zeros(
+                (
+                    calculate_zeros_width(in_features, self.group_size) * pack_num,
+                    out_features,
+                ),
+                dtype=torch.float16,
+                device=dev,
+            ),
+        )
+
+        if bias:
+            self.register_buffer(
+                "bias", torch.zeros((out_features), dtype=torch.float16, device=dev)
+            )
+        else:
+            self.bias = None
+
+    @classmethod
+    def from_linear(
+        cls, linear, w_bit, group_size, init_only=False, scales=None, zeros=None
+    ):
+        awq_linear = cls(
+            w_bit,
+            group_size,
+            linear.in_features,
+            linear.out_features,
+            linear.bias is not None,
+            linear.weight.device,
+        )
+        if init_only:
+            return awq_linear
+
+        # need scales and zeros info for real quantization
+        assert scales is not None and zeros is not None
+        scale_zeros = zeros * scales
+
+        pack_num = 32 // awq_linear.w_bit
+        qscales = torch.zeros(
+            (
+                scales.shape[0],
+                calculate_zeros_width(linear.in_features, group_size) * pack_num,
+            ),
+            dtype=torch.float16,
+            device=scales.device,
+        )
+        qscales[:, : scales.shape[1]] = scales
+        # awq_linear.scales = scales.clone().half()
+        awq_linear.scales = qscales.transpose(1, 0).contiguous()
+        if linear.bias is not None:
+            awq_linear.bias = linear.bias.clone().half()
+
+        intweight = []
+        for idx in range(awq_linear.in_features):
+            intweight.append(
+                torch.round(
+                    (linear.weight.data[:, idx] + scale_zeros[:, idx // group_size])
+                    / qscales[:, idx // group_size]
+                ).to(torch.int)[:, None]
+            )
+        intweight = torch.cat(intweight, dim=1)
+        intweight = intweight.to(dtype=torch.int32)
+        awq_linear.qweight = pack_intweight(
+            intweight.contiguous(), interleave=4, kstride=64
+        )
+
+        zeros = zeros.to(dtype=torch.int32)
+        scaled_zeros = torch.zeros_like(qscales)
+
+        scaled_zeros[:, : scales.shape[1]] = -(
+            qscales[:, : scales.shape[1]] * (zeros.to(torch.float32))
+        ).to(torch.float16)
+        awq_linear.scaled_zeros = scaled_zeros.transpose(1, 0).contiguous()
+
+        return awq_linear
+
+    @torch.no_grad()
+    def forward(self, x):
+        inputs = x
+        if inputs.numel() / inputs.shape[-1] < 8:
+            out = awq_v2_ext.gemv_forward_cuda_new(
+                inputs,
+                self.qweight,
+                self.scales,
+                self.scaled_zeros,
+                inputs.numel() // inputs.shape[-1],
+                self.out_features,
+                self.in_features,
+                self.group_size,
+            )
+        else:
+            out = awq_v2_ext.gemm_forward_cuda_new(
+                inputs, self.qweight, self.scales, self.scaled_zeros
+            )
+        out = out + self.bias if self.bias is not None else out
+
+        return out

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -9,9 +9,12 @@ from collections import defaultdict
 from awq.utils.calib_data import get_calib_dataset
 from awq.quantize.scale import apply_scale, apply_clip
 from awq.utils.utils import clear_memory, get_best_device
-from awq.modules.linear.gemm import WQLinear_GEMM
-from awq.modules.linear.gemv import WQLinear_GEMV
-from awq.modules.linear.marlin import WQLinear_Marlin
+from awq.modules.linear import (
+    WQLinear_GEMM,
+    WQLinear_GEMV,
+    WQLinear_Marlin,
+    WQLinear_GEMVFast,
+)
 from awq.utils.module import (
     append_str_prefix,
     get_op_name,
@@ -200,6 +203,9 @@ class AwqQuantizer:
 
             elif self.version == "marlin":
                 q_linear_module = WQLinear_Marlin
+            
+            elif self.version == "gemv_fast":
+                q_linear_module = WQLinear_GEMVFast
 
             else:
                 raise ValueError(f"Unknown version {self.version}")

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -466,6 +466,7 @@ class AwqQuantizer:
             self.model(samples.to(next(self.model.parameters()).device))
         except ValueError:  # work with early exit
             pass
+        modules[0] = modules[0].module  # restore
 
         # Update the layer kwargs with `prepare_inputs_for_generation` method
         # that takes care of everything to avoid unexpected errors.
@@ -474,7 +475,6 @@ class AwqQuantizer:
         layer_kwargs.pop("input_ids")
 
         del samples
-        modules[0] = modules[0].module  # restore
         inps = inps[0]
 
         modules[0] = modules[0].cpu()

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -117,11 +117,12 @@ def run_round(generator, model_path, quant_file, n_generate, input_ids, batch_si
             raise RuntimeError(ex)
 
     total_memory_used = 0
+    memory_pct = 100
     if successful_generate:
         # number of tokens in context / time for processing context * batch size
-        prefill_tokens_per_second = input_ids.shape[1] / context_time * batch_size
+        prefill_tokens_per_second = round(input_ids.shape[1] / context_time * batch_size, 2)
         # 1 second / median time per token in seconds * batch size
-        decode_tokens_per_second = 1 / np.median(generate_time) * batch_size
+        decode_tokens_per_second = round(1 / np.median(generate_time) * batch_size, 2)
 
         print(f" ** Speed (Prefill): {prefill_tokens_per_second:.2f} tokens/second")
         print(f" ** Speed (Decode): {decode_tokens_per_second:.2f} tokens/second")

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ requirements = [
     "transformers>=4.35.0",
     "tokenizers>=0.12.1",
     "typing_extensions>=4.8.0",
-    "triton",
     "accelerate",
     "datasets",
     "zstandard",


### PR DESCRIPTION
New kernels from https://github.com/mit-han-lab/llm-awq/pull/142 that scale better. They are as fast as ExLlamaV2 kernels at batch size 1 and 63% faster at larger batch sizes. Additionally, it is more memory efficient, saving GB of memory when scaling up.

GPU: NVIDIA GeForce RTX 4090
Model: Mistral 7B Instruct

### New kernel

|   Batch Size |   Prefill Length |   Decode Length |   Prefill tokens/s |   Decode tokens/s | Memory (VRAM)    |
|-------------:|-----------------:|----------------:|-------------------:|------------------:|:-----------------|
|            1 |               32 |              32 |            153.108 |           181.792 | 4.47 GB (18.90%) |
|            1 |               64 |              64 |           4986.08  |           184.787 | 4.48 GB (18.96%) |
|            1 |              128 |             128 |           6445.57  |           183.334 | 4.49 GB (19.00%) |
|            1 |              256 |             256 |           7903.41  |           178.064 | 4.51 GB (19.08%) |
|            1 |              512 |             512 |           8918.64  |           168.751 | 4.55 GB (19.24%) |
|            1 |             1024 |            1024 |           7338.22  |           152.792 | 4.63 GB (19.56%) |
|            1 |             2048 |            2048 |           5690.87  |           128.262 | 5.63 GB (23.80%) |
|            1 |             4096 |            4096 |           3843.33  |           129.923 | 9.82 GB (41.54%) |
|            8 |               32 |              32 | 990  | 1324 | 4.50 GB (19.02%)  |
|            8 |               64 |              64 | 9628  | 1323 | 4.54 GB (19.18%)  |
|            8 |              128 |             128 | 9656    | 1309 | 4.60 GB (19.45%)  |
|            8 |              256 |             256 | 9036    | 1265 | 4.72 GB (19.97%)  |
|            8 |              512 |             512 | 7992 | 1191 | 5.31 GB (22.45%)  |
|            8 |             1024 |            1024 | 6922  | 1070  | 7.92 GB (33.49%)  |
|            8 |             2048 |            2048 | 5520  | 892   | 16.90 GB (71.44%) |
|           16 |               32 |              32 | 1997.92            | 2591.88           | 4.53 GB (19.14%)  |
|           16 |               64 |              64 | 9916.44            | 2583.3            | 4.60 GB (19.44%)  |
|           16 |              128 |             128 | 9446.14            | 2547.31           | 4.72 GB (19.96%)  |
|           16 |              256 |             256 | 8663.37            | 2426.64           | 5.22 GB (22.08%)  |
|           16 |              512 |             512 | 7967.01            | 2221.12           | 6.65 GB (28.13%)  |
|           16 |             1024 |            1024 | 6924.81            | 1897.71           | 11.86 GB (50.14%) |
|           32 |               32 |              32 | 3353.53            | 4248.61           | 4.59 GB (19.40%)  |
|           32 |               64 |              64 | 9677.23            | 4154.19           | 4.72 GB (19.95%)  |
|           32 |              128 |             128 | 9109.03            | 4044.9            | 5.22 GB (22.06%)  |
|           32 |              256 |             256 | 8595.1             | 3770.58           | 6.49 GB (27.42%)  |
|           32 |              512 |             512 | 7937.57            | 3275.92           | 9.34 GB (39.50%)  |

### ExLlamaV2

|   Batch Size |   Prefill Length |   Decode Length |   Prefill tokens/s |   Decode tokens/s | Memory (VRAM)     |
|-------------:|-----------------:|----------------:|-------------------:|------------------:|:------------------|
|            1 |               32 |              32 |             151.36 |           186.248 | 4.53 GB (19.15%)  |
|            1 |               64 |              64 |            1005.16 |           186.704 | 4.54 GB (19.21%)  |
|            1 |              128 |             128 |            3447    |           185.016 | 4.56 GB (19.27%)  |
|            1 |              256 |             256 |            6128.1  |           179.998 | 4.58 GB (19.38%)  |
|            1 |              512 |             512 |            8355.09 |           170.445 | 4.64 GB (19.60%)  |
|            1 |             1024 |            1024 |            8192.38 |           154.214 | 4.74 GB (20.05%)  |
|            1 |             2048 |            2048 |            6539.28 |           129.506 | 5.77 GB (24.41%)  |
|            1 |             4096 |            4096 |            4280.31 |           130.978 | 10.08 GB (42.61%) |
|            8 |               32 |              32 | 1037 | 1154 | 4.57 GB (19.32%)  |
|            8 |               64 |              64 | 8909  | 1150 | 4.62 GB (19.54%)  |
|            8 |              128 |             128 | 11235 | 1141 | 4.71 GB (19.93%)  |
|            8 |              256 |             256 | 11426  | 1109 | 4.90 GB (20.71%)  |
|            8 |              512 |             512 | 10215 | 1050 | 5.56 GB (23.52%)  |
|            8 |             1024 |            1024 | 8716  | 953  | 8.39 GB (35.48%)  |
|            8 |             2048 |            2048 | 6627  | 808  | 17.80 GB (75.28%) |
|           16 |               32 |              32 | 1960.73            | 2048.13           | 4.61 GB (19.51%)  |
|           16 |               64 |              64 | 11457.77           | 2023.67           | 4.71 GB (19.92%)  |
|           16 |              128 |             128 | 12099.81           | 1992.66           | 4.89 GB (20.69%)  |
|           16 |              256 |             256 | 11357.77           | 1917.56           | 5.47 GB (23.14%)  |
|           16 |              512 |             512 | 10438.64           | 1785.0            | 7.12 GB (30.12%)  |
|           16 |             1024 |            1024 | 8807.95            | 1565.22           | 12.77 GB (53.98%) |
|           32 |               32 |              32 | 3370.3             | 2278.66           | 4.70 GB (19.89%)  |
|           32 |               64 |              64 | 12461.55           | 2259.29           | 4.89 GB (20.68%)  |
|           32 |              128 |             128 | 12169.56           | 2226.39           | 5.47 GB (23.13%)  |
|           32 |              256 |             256 | 11562.06           | 2150.82           | 6.96 GB (29.41%)  |
|           32 |              512 |             512 | 10565.37           | 1995.27           | 10.25 GB (43.34%) |