### PR TITLE
modify example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ tokens = tokenizer(
 generation_output = model.generate(
     tokens, 
     streamer=streamer,
-    max_seq_len=512
+    max_new_tokens=512
 )
 ```
 


### PR DESCRIPTION
The parameter named `max_seq_len` in README is incorrect.
So, I referred to the [generate.py](https://github.com/casper-hansen/AutoAWQ/blob/main/examples/generate.py) code and changed it to `max_new_tokens`

<img width="331" alt="스크린샷 2024-02-28 오후 9 41 29" src="https://github.com/casper-hansen/AutoAWQ/assets/47784418/74b5838e-942c-4ccc-a3a4-2bea1e4a2483">
