### PR TITLE
FIX: Add safe guards for static cache + llama on transformers latest

### DIFF
--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -188,16 +188,19 @@ class QuantAttentionFused(nn.Module):
             # Always reset to 0
             self.start_pos = 0
 
+        hf_is_generating = False
+
+        if self.is_hf_transformers and "use_cache" in kwargs:
+            hf_is_generating = kwargs["use_cache"]
+
+
         # In case we re-generate, we need to refresh the starting position
         # to 0. We detect it by checking if `past_key_values` is set to None,
         # which indicates that we are on the first step of `generate()`.
         # This is only applicable for `transformers` integration
-        if (
-            self.is_hf_transformers
-            and "past_key_value" in kwargs
-            and kwargs["past_key_value"] is None
-        ):
+        if self.is_hf_transformers and "past_key_value" in kwargs and kwargs["past_key_value"] is None:
             self.start_pos = 0
+    
 
         xqkv = self.qkv_proj(hidden_states)
         xqkv = xqkv.view((bsz, seqlen) + self.attention_shapes["xqkv_view"])
@@ -214,8 +217,6 @@ class QuantAttentionFused(nn.Module):
             if not self.use_alibi:
                 xq, xk = self.rope.forward(xq, xk, self.start_pos, seqlen)
 
-            self.cache.to(xq)
-
             values_store = xv.transpose(2, 1)
             keys_store = (
                 xk.reshape((bsz, seqlen) + self.attention_shapes["xk_reshape"])
@@ -223,10 +224,12 @@ class QuantAttentionFused(nn.Module):
                 .contiguous()
             )
 
-            self.cache.update_kv(values_store, keys_store, bsz, self.start_pos, seqlen)
+            if hf_is_generating:
+                self.cache.to(xq)
+                self.cache.update_kv(values_store, keys_store, bsz, self.start_pos, seqlen)
 
             # Only necessary to retrieve from cache when we are not processing context
-            if seqlen == 1:
+            if seqlen == 1 and hf_is_generating:
                 xv, xk = self.cache.get_kv(bsz, self.start_pos, seqlen, self.head_dim)
 
             keys = xk
@@ -248,6 +251,11 @@ class QuantAttentionFused(nn.Module):
 
             # When seqlen is 1, there is nothing else to attend to
             if attention_mask is not None and seqlen > 1:
+                # For llama-arch, the causal mask is preallocated with bsz x 1 x max_seq_len x max_seq_len, thus we 
+                # need to slice it
+                if attention_mask.shape[-1] != seqlen:
+                    attention_mask = attention_mask[:, :, :seqlen, :seqlen]
+
                 scores = (
                     scores + attention_mask
                 )  # (bs, n_local_heads, slen, cache_len + slen)
@@ -276,14 +284,18 @@ class QuantAttentionFused(nn.Module):
             attention_weight = attention_weight.reshape(bsz, 1, -1)
 
         attn_output = self.o_proj(attention_weight)
-        self.start_pos += seqlen
+        if hf_is_generating:
+            self.start_pos += seqlen
+        else:
+            self.start_pos = 0
 
         # past_key_value is replaced with cache_v, cache_k, returning empty data
         # we pass a dummy past kv cache for transformers to be able to retrieve the correct info
         # about past key length
-        past_key_value = [torch.zeros(1, 1, self.start_pos, 1)]
+        past_key_value = [torch.zeros(1, 1, self.start_pos, 1)] if hf_is_generating else None
 
-        if HF_NEW_CACHE_FORMAT and self.is_hf_transformers:
+
+        if HF_NEW_CACHE_FORMAT and self.is_hf_transformers and hf_is_generating:
             new_cache = DynamicCache()
             new_cache.update(past_key_value[0], past_key_value[0], layer_idx=0)
             past_key_value = new_cache


### PR DESCRIPTION
Fixes: https://github.com/huggingface/transformers/issues/28470

This PR makes autoawq + transformers compatible with recent changes on Llama architecture. In transformers llama the causal mask is pre-allocated with the size `bsz, 1, max_seq_len, max_seq_len`, thus needing to slice the attention mask here in the fused attention module.

Also fixes an issue where running this script fails: 

Script to repro:

```python
from transformers import AutoModelForCausalLM, AwqConfig, AutoTokenizer

awq_config = AwqConfig(do_fuse=True, fuse_max_seq_len=512)
model = AutoModelForCausalLM.from_pretrained(
    "casperhansen/tinyllama-1b-awq",
    quantization_config=awq_config,
).to("cuda")

tokenizer = AutoTokenizer.from_pretrained("casperhansen/tinyllama-1b-awq")
input_ids = tokenizer("Hello, my dog is cute", return_tensors="pt").input_ids.to("cuda")

model.forward(input_ids, use_cache=False)
model.generate(input_ids, max_new_tokens=100)
```

We defer to not using the caching logic if `use_cache=False`

cc @casper-hansen 