### PR TITLE
Add StableLM support

### DIFF
--- a/awq/models/__init__.py
+++ b/awq/models/__init__.py
@@ -15,3 +15,4 @@ from .llava import LlavaAWQForCausalLM
 from .mixtral import MixtralAWQForCausalLM
 from .qwen2 import Qwen2AWQForCausalLM
 from .gemma import GemmaAWQForCausalLM
+from .stablelm import StableLmAWQForCausalLM

--- a/awq/models/auto.py
+++ b/awq/models/auto.py
@@ -24,6 +24,7 @@ AWQ_CAUSAL_LM_MODEL_MAP = {
     "llava": LlavaAWQForCausalLM,
     "qwen2": Qwen2AWQForCausalLM,
     "gemma": GemmaAWQForCausalLM,
+    "stablelm": StableLmAWQForCausalLM,
 }
 
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -68,6 +68,7 @@ TRANSFORMERS_AUTO_MAPPING_DICT = {
     "llava": "AutoModelForVision2Seq",
     "qwen2": "AutoModelForCausalLM",
     "gemma": "AutoModelForCausalLM",
+    "stablelm": "AutoModelForCausalLM",
 }
 
 

--- a/awq/models/stablelm.py
+++ b/awq/models/stablelm.py
@@ -90,10 +90,10 @@ class StableLmFuser:
     def __init__(self, model: OldStableLmForCausalLM):
         self.model = model
 
-        self.qwen2_blocks: List[Tuple[str, OldStableLmDecoderLayer]] = [
+        self.stablelm_blocks: List[Tuple[str, OldStableLmDecoderLayer]] = [
             (name, module)
             for name, module in self.model.named_modules()
-            if "Qwen2DecoderLayer".lower() in module.__class__.__name__.lower()
+            if "StableLmDecoderLayer".lower() in module.__class__.__name__.lower()
         ]
 
     def fuse_transformer(self):

--- a/awq/models/stablelm.py
+++ b/awq/models/stablelm.py
@@ -1,0 +1,139 @@
+import tqdm
+from typing import List, Tuple
+from .base import BaseAWQForCausalLM
+from awq.utils.fused_utils import fuse_qkv
+from awq.modules.fused.block import LlamaLikeBlock
+from awq.modules.fused.model import LlamaLikeModel
+from transformers.models.stablelm import StableLmForCausalLM as OldStableLmForCausalLM
+from transformers.models.stablelm.modeling_stablelm import (
+    StableLmDecoderLayer as OldStableLmDecoderLayer,
+)
+from awq.modules.fused.norm import FasterTransformerRMSNorm
+
+
+class StableLmAWQForCausalLM(BaseAWQForCausalLM):
+    layer_type = "StableLmDecoderLayer"
+    max_seq_len_key = "max_position_embeddings"
+
+    @staticmethod
+    def fuse_layers(model: OldStableLmForCausalLM):
+        fuser = StableLmFuser(model)
+        fuser.fuse_transformer()
+
+    @staticmethod
+    def get_model_layers(model: OldStableLmForCausalLM):
+        return model.model.layers
+
+    @staticmethod
+    def get_act_for_scaling(module: OldStableLmForCausalLM):
+        return dict(is_scalable=False)
+
+    @staticmethod
+    def move_embed(model: OldStableLmForCausalLM, device: str):
+        model.model.embed_tokens = model.model.embed_tokens.to(device)
+
+    @staticmethod
+    def get_layers_for_scaling(
+        module: OldStableLmDecoderLayer, input_feat, module_kwargs
+    ):
+        layers = []
+
+        # attention input
+        layers.append(
+            dict(
+                prev_op=module.input_layernorm,
+                layers=[
+                    module.self_attn.q_proj,
+                    module.self_attn.k_proj,
+                    module.self_attn.v_proj,
+                ],
+                inp=input_feat["self_attn.q_proj"],
+                module2inspect=module.self_attn,
+                kwargs=module_kwargs,
+            )
+        )
+
+        # attention out
+        # Please refer to https://github.com/mit-han-lab/llm-awq/pull/67#issue-1850622696
+        if module.self_attn.v_proj.weight.shape == module.self_attn.o_proj.weight.shape:
+            layers.append(
+                dict(
+                    prev_op=module.self_attn.v_proj,
+                    layers=[module.self_attn.o_proj],
+                    inp=input_feat["self_attn.o_proj"],
+                )
+            )
+
+        # linear 1
+        layers.append(
+            dict(
+                prev_op=module.post_attention_layernorm,
+                layers=[module.mlp.gate_proj, module.mlp.up_proj],
+                inp=input_feat["mlp.gate_proj"],
+                module2inspect=module.mlp,
+            )
+        )
+
+        # linear 2
+        layers.append(
+            dict(
+                prev_op=module.mlp.up_proj,
+                layers=[module.mlp.down_proj],
+                inp=input_feat["mlp.down_proj"],
+            )
+        )
+
+        return layers
+
+
+class StableLmFuser:
+    def __init__(self, model: OldStableLmForCausalLM):
+        self.model = model
+
+        self.qwen2_blocks: List[Tuple[str, OldStableLmDecoderLayer]] = [
+            (name, module)
+            for name, module in self.model.named_modules()
+            if "Qwen2DecoderLayer".lower() in module.__class__.__name__.lower()
+        ]
+
+    def fuse_transformer(self):
+        blocks = []
+
+        module: OldStableLmDecoderLayer
+        for module in tqdm.tqdm(self.model.model.layers, desc="Fusing layers..."):
+            device = next(iter(module.state_dict().values())).device
+            qkv = fuse_qkv(
+                module,
+                module.self_attn.q_proj,
+                module.self_attn.k_proj,
+                module.self_attn.v_proj,
+            )
+            norm_1 = FasterTransformerRMSNorm(
+                module.input_layernorm.weight, module.input_layernorm.eps
+            )
+            norm_2 = FasterTransformerRMSNorm(
+                module.post_attention_layernorm.weight,
+                module.post_attention_layernorm.eps,
+            )
+            blocks.append(
+                LlamaLikeBlock(
+                    hidden_size=self.model.config.hidden_size,
+                    n_heads=self.model.config.num_attention_heads,
+                    n_kv_heads=self.model.config.num_key_value_heads,
+                    qkv_layer=qkv,
+                    o_proj=module.self_attn.o_proj,
+                    mlp=module.mlp,
+                    norm_1=norm_1,
+                    norm_2=norm_2,
+                    dev=device,
+                    max_seq_len=self.model.config.max_seq_len,
+                )
+            )
+
+        self.model.model = LlamaLikeModel(
+            self.model.config.vocab_size,
+            blocks,
+            self.model.model.embed_tokens,
+            self.model.model.norm,
+        )
+        setattr(self.model.model, "blocks", self.model.model.blocks)

--- a/awq/models/stablelm.py
+++ b/awq/models/stablelm.py
@@ -108,13 +108,8 @@ class StableLmFuser:
                 module.self_attn.k_proj,
                 module.self_attn.v_proj,
             )
-            norm_1 = FasterTransformerRMSNorm(
-                module.input_layernorm.weight, module.input_layernorm.eps
-            )
-            norm_2 = FasterTransformerRMSNorm(
-                module.post_attention_layernorm.weight,
-                module.post_attention_layernorm.eps,
-            )
+            norm_1 = module.input_layernorm
+            norm_2 = module.post_attention_layernorm
             blocks.append(
                 LlamaLikeBlock(
                     hidden_size=self.model.config.hidden_size,
@@ -127,6 +122,8 @@ class StableLmFuser:
                     norm_2=norm_2,
                     dev=device,
                     max_seq_len=self.model.config.max_seq_len,
+                    rope_theta=self.model.config.rope_theta,
+                    partial_rotary_factor=self.model.config.partial_rotary_factor,
                 )
             )
 

--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -283,7 +283,7 @@ class QuantAttentionFused(nn.Module):
                 None,  # length per sample
                 alibi_slopes,  # alibi slopes
                 self.start_pos,  # timestep
-                self.rotary_dim//self.partial_rotary_factor,  # rotary embedding dimension
+                self.rotary_dim,  # rotary embedding dimension
                 self.rope_theta,  # rotary embedding base
                 self.is_neox,  # is neox
             )

--- a/awq/modules/fused/block.py
+++ b/awq/modules/fused/block.py
@@ -79,6 +79,7 @@ class LlamaLikeBlock(nn.Module):
         dev,
         max_seq_len,
         rope_theta=10000,
+        partial_rotary_factor=1.0,
         use_alibi=False,
         head_dim=None,
     ):
@@ -103,6 +104,7 @@ class LlamaLikeBlock(nn.Module):
             max_seq_len=max_seq_len,
             use_alibi=use_alibi,
             rope_theta=rope_theta,
+            partial_rotary_factor=partial_rotary_factor,
             head_dim=head_dim,
         ).to(dev)
         self.norm_2 = norm_2.to(dev)


### PR DESCRIPTION
Related issue:
- #327 

Features:
- Add `stabilityai/stable-code-3b` support
- Support partial ROPE in `QuantAttentionFused` (partial rotary embedding used in `stablelm` and `phi-2`)