### PR TITLE
Fix fused models for tf >= 4.39

### DIFF
--- a/awq/modules/fused/model.py
+++ b/awq/modules/fused/model.py
@@ -83,6 +83,14 @@ class LlamaLikeModel(nn.Module):
         self.blocks: List[LlamaLikeBlock] = nn.ModuleList(blocks)
         self.norm = norm
         self.last_forward_num_tokens = 0
+        
+    @property
+    def embed_tokens(self):
+        return self.embedding
+    
+    @property
+    def layers(self):
+        return self.blocks
 
     @torch.inference_mode()
     def forward(

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ common_setup_kwargs = {
 
 requirements = [
     "torch>=2.0.1",
-    "transformers>=4.35.0,<=4.38.2",
+    "transformers>=4.35.0",
     "tokenizers>=0.12.1",
     "typing_extensions>=4.8.0",
     "accelerate",


### PR DESCRIPTION
Fix #407 and #417

The latest main branch of transformer has solved the problems of quantization and inference. This pr solves the error reporting using fused models.