### PR TITLE
[BUG] Fix github action documentation build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: 3.11
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
The docs build is giving an error while trying to evaluate awq from python 3.12, when it doesn't exist in that version yet.

This change forces the use of python 3.11