### PR TITLE
Fix NameError when checking possible undefined variable

### DIFF
--- a/awq/modules/linear/gemm.py
+++ b/awq/modules/linear/gemm.py
@@ -63,7 +63,7 @@ class WQLinearMMFunction(Function):
     def backward(ctx, grad_output):
         input, qweight, qzeros, scales, bias = ctx.saved_tensors
 
-        if awq_ext is None:
+        if not AWQ_INSTALLED:
             raise ValueError(
                 "auto-awq kernels is needed to be installed to use `.backward()`. Make sure to install the auto-awq kernels"
                 " by following the installation guides in https://github.com/casper-hansen/AutoAWQ_kernels"


### PR DESCRIPTION
If awq_ext is not installed then it is undefined and results in a cryptic NameError message instead of the intended exception. This pull-request fixes that