### PR TITLE
add support for Openbmb/MiniCPM

### DIFF
--- a/awq/models/__init__.py
+++ b/awq/models/__init__.py
@@ -19,3 +19,4 @@ from .stablelm import StableLmAWQForCausalLM
 from .starcoder2 import Starcoder2AWQForCausalLM
 from .phi3 import Phi3AWQForCausalLM
 from .cohere import CohereAWQForCausalLM
+from .minicpm import MiniCPMAWQForCausalLM

--- a/awq/models/auto.py
+++ b/awq/models/auto.py
@@ -28,6 +28,7 @@ AWQ_CAUSAL_LM_MODEL_MAP = {
     "starcoder2": Starcoder2AWQForCausalLM,
     "phi3": Phi3AWQForCausalLM,
     "cohere": CohereAWQForCausalLM,
+    "minicpm": MiniCPMAWQForCausalLM,
 }
 
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -80,6 +80,7 @@ TRANSFORMERS_AUTO_MAPPING_DICT = {
     "starcoder2": "AutoModelForCausalLM",
     "phi3": "AutoModelForCausalLM",
     "cohere": "AutoModelForCausalLM",
+    "minicpm":"AutoModelForCausalLM"
 }
 
 

--- a/awq/models/minicpm.py
+++ b/awq/models/minicpm.py
@@ -1,0 +1,62 @@
+
+from .base import BaseAWQForCausalLM
+
+
+class MiniCPMAWQForCausalLM(BaseAWQForCausalLM):
+    layer_type = "MiniCPMDecoderLayer"
+    max_seq_len_key = "seq_length"
+
+    @staticmethod
+    def get_model_layers(model):
+        return model.model.layers
+
+    @staticmethod
+    def get_act_for_scaling(module):
+        return dict(is_scalable=False)
+
+    @staticmethod
+    def move_embed(model, device: str):
+        model.model.embed_tokens = model.model.embed_tokens.to(device)
+
+    @staticmethod
+    def get_layers_for_scaling(module, input_feat, module_kwargs):
+        layers = []
+
+        
+
+        # # mlp
+        layers.append(
+            dict(
+                prev_op=module.input_layernorm,
+                layers=[
+                    module.self_attn.q_proj,
+                    module.self_attn.k_proj,
+                    module.self_attn.v_proj,
+                ],
+                inp=input_feat["self_attn.q_proj"],
+                module2inspect=module.self_attn,
+                kwargs=module_kwargs,
+            )
+        )
+
+        # linear 2
+        layers.append(
+            dict(
+                prev_op=module.mlp.up_proj,
+                layers=[module.mlp.down_proj],
+                inp=input_feat["mlp.down_proj"],
+            )
+        )
+
+        layers.append(
+            dict(
+                prev_op=module.post_attention_layernorm,
+                layers=[module.mlp.gate_proj,module.mlp.up_proj],
+                inp=input_feat["mlp.gate_proj"],
+                module2inspect=module.mlp
+            )
+        )
+
+        return layers
+
+


### PR DESCRIPTION
Hello, I am a staff member of openbmb responsible for the open source community. In this pull request, support for our openbmb/MiniCPM model has been added. The following huggingface address of the awq quantitative model:
[MiniCPM2_2b_awq_int4](https://huggingface.co/openbmb/MiniCPM2_2b_awq_int4/tree/main)
[MiniCPM2_1b_awq_int4](https://huggingface.co/openbmb/MiniCPM2_1b_awq_int4/tree/main)


I also completed the perplexity test of the above model on the wikitext test set, and the results are as follows:

awq model： awq_cpm_1b_4bit
gpu usage: 1.54GB
Perplexity 8.867: 100%|███████████████████████████████████████████| 164/164 [00:28<00:00,  5.84it/s]
pretrained model： MiniCPM-1B-sft-bf16
gpu usage: 3.24GB
Perplexity 8.576: 100%|███████████████████████████████████████████| 164/164 [00:10<00:00, 15.25it/s]
gptq model： minicpm_1b_4bit
gpu usage: 1.9GB
Perplexity 9.416: 100%|███████████████████████████████████████████| 164/164 [00:09<00:00, 17.81it/s]


awq model： awq_cpm_2b_4bit
gpu usage: 2.75GB
Perplexity 8.152: 100%|███████████████████████████████████████████| 159/159 [00:33<00:00,  4.70it/s]
pretrained model： miniCPM-bf16
gpu usage: 5.93GB
Perplexity 7.981: 100%|███████████████████████████████████████████| 159/159 [00:17<00:00,  9.18it/s]
gptq model： minicpm_2b_4bit
gpu usage: 3.02GB
Perplexity 8.669: 100%|███████████████████████████████████████████| 159/159 [00:14<00:00, 10.65it/s]
If the above code meets your requirements, we look forward to merging it into the master branch.