### PR TITLE
add deepseek v2 support

### DIFF
--- a/awq/models/__init__.py
+++ b/awq/models/__init__.py
@@ -19,3 +19,4 @@ from .stablelm import StableLmAWQForCausalLM
 from .starcoder2 import Starcoder2AWQForCausalLM
 from .phi3 import Phi3AWQForCausalLM
 from .cohere import CohereAWQForCausalLM
+from .deepseek_v2 import DeepseekV2AWQForCausalLM

--- a/awq/models/auto.py
+++ b/awq/models/auto.py
@@ -28,6 +28,7 @@ AWQ_CAUSAL_LM_MODEL_MAP = {
     "starcoder2": Starcoder2AWQForCausalLM,
     "phi3": Phi3AWQForCausalLM,
     "cohere": CohereAWQForCausalLM,
+    "deepseek_v2": DeepseekV2AWQForCausalLM,
 }
 
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -80,6 +80,7 @@ TRANSFORMERS_AUTO_MAPPING_DICT = {
     "starcoder2": "AutoModelForCausalLM",
     "phi3": "AutoModelForCausalLM",
     "cohere": "AutoModelForCausalLM",
+    "deepseek_v2": "AutoModelForCausalLM",
 }
 
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -506,6 +506,8 @@ class BaseAWQForCausalLM(nn.Module):
                 max_batch_size=int(os.getenv("AWQ_BATCH_SIZE", 1)),
             )
 
+        model.eval()
+
         return self(
             model,
             model_type,

--- a/awq/models/deepseek_v2.py
+++ b/awq/models/deepseek_v2.py
@@ -1,0 +1,129 @@
+import tqdm
+from typing import List, Tuple
+from .base import BaseAWQForCausalLM
+
+
+class DeepseekV2AWQForCausalLM(BaseAWQForCausalLM):
+    layer_type = "DeepseekV2DecoderLayer"
+    max_seq_len_key = "max_position_embeddings"
+    modules_to_not_convert = ["mlp.gate"]
+
+    @staticmethod
+    def get_model_layers(model):
+        return model.model.layers
+
+    @staticmethod
+    def get_act_for_scaling(module):
+        return dict(is_scalable=False)
+
+    @staticmethod
+    def move_embed(model, device: str):
+        model.model.embed_tokens = model.model.embed_tokens.to(device)
+
+    @staticmethod
+    def get_layers_for_scaling(
+        module, input_feat, module_kwargs
+    ):
+        layers = []
+
+        if hasattr(module.self_attn, "q_proj"):
+            # attention input
+            layers.append(
+                dict(
+                    prev_op=module.input_layernorm,
+                    layers=[
+                        module.self_attn.q_proj,
+                        module.self_attn.kv_a_proj_with_mqa,
+                    ],
+                    inp=input_feat["self_attn.q_proj"],
+                    module2inspect=module.self_attn,
+                    kwargs=module_kwargs,
+                )
+            )
+        else:
+            # attention input
+            layers.append(
+                dict(
+                    prev_op=module.input_layernorm,
+                    layers=[
+                        module.self_attn.q_a_proj,
+                        module.self_attn.kv_a_proj_with_mqa,
+                    ],
+                    inp=input_feat["self_attn.q_proj"],
+                    module2inspect=module.self_attn,
+                    kwargs=module_kwargs,
+                )
+            )
+            layers.append(
+                dict(
+                    prev_op=module.self_attn.q_a_layernorm,
+                    layers=[
+                        module.self_attn.q_b_proj,
+                    ],
+                    inp=input_feat["self_attn.q_b_proj"],
+                )
+            )
+
+        # kv layernorm
+        layers.append(
+            dict(
+                prev_op=module.self_attn.kv_a_layernorm,
+                layers=[
+                    module.self_attn.kv_b_proj,
+                ],
+                inp=input_feat["self_attn.kv_b_proj"],
+            )
+        )
+
+        if hasattr(module.mlp, "gate"):
+            # linear in
+            layers.append(
+                dict(
+                    prev_op=module.post_attention_layernorm,
+                    layers=[
+                        w
+                        for expert in module.mlp.experts
+                        for w in [expert.gate_proj, expert.up_proj]
+                    ] + [module.mlp.shared_experts.gate_proj, module.mlp.shared_experts.up_proj],
+                    inp=input_feat["mlp"],
+                    module2inspect=module.mlp,
+                )
+            )
+
+            # linear out
+            for i, expert in enumerate(module.mlp.experts):
+                layers.append(
+                    dict(
+                        prev_op=expert.up_proj,
+                        layers=[expert.down_proj],
+                        inp=input_feat[f"mlp.experts.{i}.down_proj"],
+                    )
+                )
+            layers.append(
+                dict(
+                    prev_op=module.mlp.shared_experts.up_proj,
+                    layers=[module.mlp.shared_experts.down_proj],
+                    inp=input_feat[f"mlp.shared_experts.down_proj"],
+                )
+            )
+        else:
+            # linear 1
+            layers.append(
+                dict(
+                    prev_op=module.post_attention_layernorm,
+                    layers=[module.mlp.gate_proj, module.mlp.up_proj],
+                    inp=input_feat["mlp.gate_proj"],
+                    module2inspect=module.mlp,
+                )
+            )
+
+            # linear 2
+            layers.append(
+                dict(
+                    prev_op=module.mlp.up_proj,
+                    layers=[module.mlp.down_proj],
+                    inp=input_feat["mlp.down_proj"],
+                )
+            )
+
+        return layers

--- a/awq/models/deepseek_v2.py
+++ b/awq/models/deepseek_v2.py
@@ -6,7 +6,6 @@ from .base import BaseAWQForCausalLM
 class DeepseekV2AWQForCausalLM(BaseAWQForCausalLM):
     layer_type = "DeepseekV2DecoderLayer"
     max_seq_len_key = "max_position_embeddings"
-    modules_to_not_convert = ["mlp.gate"]
 
     @staticmethod
     def get_model_layers(model):

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -522,6 +522,12 @@ class AwqQuantizer:
                 "block_sparse_moe": layer.block_sparse_moe,
             }
 
+        if self.awq_model.model_type == "deepseek_v2":
+            named_linears = {
+                **named_linears,
+                "mlp": layer.mlp,
+            }
+
         for name in named_linears:
             handles.append(
                 named_linears[name].register_forward_hook(

--- a/awq/utils/module.py
+++ b/awq/utils/module.py
@@ -54,8 +54,4 @@ def exclude_layers_to_not_quantize(linear_layers, modules_to_not_convert):
     for name, linear_layer in linear_layers.items():
         if not any(key in name for key in modules_to_not_convert):
             filtered_layers[name] = linear_layer
-        # For Deepseek-V2
-        # Do not filter mlp.gate_proj when filtering mlp.gate
-        if "mlp.gate" in modules_to_not_convert and "mlp.gate_proj" in name:
-            filtered_layers[name] = linear_layer
     return filtered_layers

--- a/awq/utils/module.py
+++ b/awq/utils/module.py
@@ -54,4 +54,8 @@ def exclude_layers_to_not_quantize(linear_layers, modules_to_not_convert):
     for name, linear_layer in linear_layers.items():
         if not any(key in name for key in modules_to_not_convert):
             filtered_layers[name] = linear_layer
+        # For Deepseek-V2
+        # Do not filter mlp.gate_proj when filtering mlp.gate
+        if "mlp.gate" in modules_to_not_convert and "mlp.gate_proj" in name:
+            filtered_layers[name] = linear_layer
     return filtered_layers


### PR DESCRIPTION
Add support for Deepseek-V2.
I wrote it with reference to the papers of deepseek and awq. It works, but there are several potential issues:
1. Due to the combination/compression strategy of mla and rope, q_group_size cannot take the commonly used 128, and the maximum is 64.
2. The performance drop after quantization is slightly more than that of common dense models like llama. A possible reason is that mla and deepseekmoe decompose both the attn and mlp layers into small matrices, which will lead to a situation a bit like quantizing small models.

In addition, the implementation of the fusion layer is lacking (while considering the complexity of implementing new operators, is it necessary to add fusion layers for all new architectures?)