### PR TITLE
Batched quantization

### DIFF
--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -81,7 +81,7 @@ TRANSFORMERS_AUTO_MAPPING_DICT = {
     "phi3": "AutoModelForCausalLM",
     "cohere": "AutoModelForCausalLM",
     "deepseek_v2": "AutoModelForCausalLM",
-    "minicpm":"AutoModelForCausalLM",
+    "minicpm": "AutoModelForCausalLM",
 }
 
 
@@ -166,16 +166,13 @@ class BaseAWQForCausalLM(nn.Module):
             ),
         ] = None,
         max_calib_samples: Annotated[
-            int,
-            Doc(
-                "The maximum number of samples to run through the model."
-            )
+            int, Doc("The maximum number of samples to run through the model.")
         ] = 128,
         max_calib_seq_len: Annotated[
             int,
             Doc(
                 "The maximum sequence length of the calibration dataset. Discard samples greater than max_calib_seq_len."
-            )
+            ),
         ] = 512,
         max_chunk_memory: Annotated[
             int,
@@ -183,8 +180,10 @@ class BaseAWQForCausalLM(nn.Module):
                 "The loss computation and per-channel mean is optimized into chunked computations."
                 " Adjust this parameter to increase or decrease memory usage for these computations."
                 " Default is 1GB (1024 * 1024 * 1024)."
-            )
-        ] = 1024 * 1024 * 1024
+            ),
+        ] = 1024
+        * 1024
+        * 1024,
     ):
         """
         The main quantization function that you can use to quantize your model.
@@ -345,7 +344,8 @@ class BaseAWQForCausalLM(nn.Module):
             ),
         ] = None,
         download_kwargs: Annotated[
-            Dict, Doc("Used for configure download model"),
+            Dict,
+            Doc("Used for configure download model"),
         ] = None,
         **model_init_kwargs: Annotated[
             Dict,
@@ -357,9 +357,12 @@ class BaseAWQForCausalLM(nn.Module):
         """A method for initialization of pretrained models, usually in FP16."""
         # Get weights path and quant config
         model_weights_path, config, quant_config = self._load_config(
-            self, model_path, "", safetensors,
+            self,
+            model_path,
+            "",
+            safetensors,
             trust_remote_code=trust_remote_code,
-            download_kwargs=download_kwargs
+            download_kwargs=download_kwargs,
         )
 
         target_cls_name = TRANSFORMERS_AUTO_MAPPING_DICT[config.model_type]
@@ -442,7 +445,7 @@ class BaseAWQForCausalLM(nn.Module):
             ),
         ] = "balanced",
         max_memory: Annotated[
-            Dict[Union[int, str], Union[int, str]], 
+            Dict[Union[int, str], Union[int, str]],
             Doc(
                 'A dictionary device identifier to maximum memory which will be passed onto the model loading method from transformers. For example：{0: "4GB",1: "10GB"'
             ),
@@ -452,7 +455,8 @@ class BaseAWQForCausalLM(nn.Module):
             Doc("The folder ot offload the model to."),
         ] = None,
         download_kwargs: Annotated[
-            Dict, Doc("Used for configure download model"),
+            Dict,
+            Doc("Used for configure download model"),
         ] = None,
         **config_kwargs: Annotated[
             Dict,
@@ -488,11 +492,15 @@ class BaseAWQForCausalLM(nn.Module):
         use_cpu_qbits = use_qbits or get_best_device() == "cpu"
         if use_cpu_qbits:
             if not qbits_available:
-                raise ImportError("Please install intel-extension-for-transformers with "
-                                  "`pip install intel-extension-for-transformers` for 'qbits' kernel!")
+                raise ImportError(
+                    "Please install intel-extension-for-transformers with "
+                    "`pip install intel-extension-for-transformers` for 'qbits' kernel!"
+                )
 
             fuse_layers = False
-            logging.warn("Unsupport fuse_layers featrue for CPU device with QBits backend!")
+            logging.warn(
+                "Unsupport fuse_layers featrue for CPU device with QBits backend!"
+            )
         # Prepare WQLinear layers, replace nn.Linear
         self._load_quantized_modules(
             self,
@@ -580,7 +588,9 @@ class BaseAWQForCausalLM(nn.Module):
                 elif isinstance(download_kwargs_ignore_patterns, list):
                     ignore_patterns.extend(download_kwargs_ignore_patterns)
 
-            model_path = snapshot_download(model_path, ignore_patterns=ignore_patterns, **download_kwargs)
+            model_path = snapshot_download(
+                model_path, ignore_patterns=ignore_patterns, **download_kwargs
+            )
 
         if model_filename != "":
             model_weights_path = model_path + f"/{model_filename}"
@@ -654,13 +664,17 @@ class BaseAWQForCausalLM(nn.Module):
                     q_linear_module = WQLinear_GEMVFast
 
                 if use_qbits:
-                    q_linear = q_linear_module.from_linear(module,
-                                                           quant_config.w_bit,
-                                                           quant_config.q_group_size,
-                                                           True,
-                                                           has_zero_points=quant_config.zero_point)
+                    q_linear = q_linear_module.from_linear(
+                        module,
+                        quant_config.w_bit,
+                        quant_config.q_group_size,
+                        True,
+                        has_zero_points=quant_config.zero_point,
+                    )
                 else:
-                    q_linear = q_linear_module.from_linear(module, quant_config.w_bit, quant_config.q_group_size, True)
+                    q_linear = q_linear_module.from_linear(
+                        module, quant_config.w_bit, quant_config.q_group_size, True
+                    )
                 q_linear.to(next(layer.parameters()).device)
                 set_op_by_name(layer, name, q_linear)
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -176,7 +176,15 @@ class BaseAWQForCausalLM(nn.Module):
             Doc(
                 "The maximum sequence length of the calibration dataset. Discard samples greater than max_calib_seq_len."
             )
-        ] = 512
+        ] = 512,
+        max_chunk_memory: Annotated[
+            int,
+            Doc(
+                "The loss computation and per-channel mean is optimized into chunked computations."
+                " Adjust this parameter to increase or decrease memory usage for these computations."
+                " Default is 1GB (1024 * 1024 * 1024)."
+            )
+        ] = 1024 * 1024 * 1024
     ):
         """
         The main quantization function that you can use to quantize your model.
@@ -218,6 +226,7 @@ class BaseAWQForCausalLM(nn.Module):
             n_parallel_calib_samples=n_parallel_calib_samples,
             max_calib_samples=max_calib_samples,
             max_calib_seq_len=max_calib_seq_len,
+            max_chunk_memory=max_chunk_memory,
         )
         self.quantizer.quantize()
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -162,6 +162,18 @@ class BaseAWQForCausalLM(nn.Module):
                 "You can set this to a low number for more memory efficient quantization."
             ),
         ] = None,
+        max_calib_samples: Annotated[
+            int,
+            Doc(
+                "The maximum number of samples to run through the model."
+            )
+        ] = 128,
+        max_calib_seq_len: Annotated[
+            int,
+            Doc(
+                "The maximum sequence length of the calibration dataset. Discard samples greater than max_calib_seq_len."
+            )
+        ] = 512
     ):
         """
         The main quantization function that you can use to quantize your model.
@@ -201,6 +213,8 @@ class BaseAWQForCausalLM(nn.Module):
             export_compatible=export_compatible,
             apply_clip=apply_clip,
             n_calib_samples=n_calib_samples,
+            max_calib_samples=max_calib_samples,
+            max_calib_seq_len=max_calib_seq_len,
         )
         self.quantizer.quantize()
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -144,6 +144,13 @@ class BaseAWQForCausalLM(nn.Module):
                 "Whether to apply clipping to the model during quantization. Some models may perform better with this set to False."
             ),
         ] = True,
+        n_calib_samples: Annotated[
+            int,
+            Doc(
+                "The number of samples to run through the model at once. If None, runs through all samples at the same time. "
+                "You can set this to a low number for more memory efficient quantization."
+            ),
+        ] = None,
     ):
         """
         The main quantization function that you can use to quantize your model.
@@ -182,6 +189,7 @@ class BaseAWQForCausalLM(nn.Module):
             modules_to_not_convert=self.quant_config.modules_to_not_convert,
             export_compatible=export_compatible,
             apply_clip=apply_clip,
+            n_calib_samples=n_calib_samples,
         )
         self.quantizer.quantize()
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -155,10 +155,12 @@ class BaseAWQForCausalLM(nn.Module):
                 "Whether to apply clipping to the model during quantization. Some models may perform better with this set to False."
             ),
         ] = True,
-        n_calib_samples: Annotated[
+        n_parallel_calib_samples: Annotated[
             int,
             Doc(
-                "The number of samples to run through the model at once. If None, runs through all samples at the same time. "
+                "The number of parallel samples to run through the model. "
+                "A high number of parallel samples can result in OOM during quantization if max_calib_samples is high enough. "
+                "If None, runs through all samples at the same time. "
                 "You can set this to a low number for more memory efficient quantization."
             ),
         ] = None,
@@ -212,7 +214,7 @@ class BaseAWQForCausalLM(nn.Module):
             modules_to_not_convert=self.quant_config.modules_to_not_convert,
             export_compatible=export_compatible,
             apply_clip=apply_clip,
-            n_calib_samples=n_calib_samples,
+            n_parallel_calib_samples=n_parallel_calib_samples,
             max_calib_samples=max_calib_samples,
             max_calib_seq_len=max_calib_seq_len,
         )

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -458,13 +458,13 @@ class AwqQuantizer:
 
         return best_max_val.squeeze(1)
 
-    def init_quant(self, n_samples=128, seqlen=512):
+    def init_quant(self, n_samples=128, max_seq_len=512):
         modules = self.awq_model.get_model_layers(self.model)
         samples = get_calib_dataset(
             data=self.calib_data,
             tokenizer=self.tokenizer,
             n_samples=n_samples,
-            block_size=seqlen,
+            max_seq_len=max_seq_len,
             split=self.split,
             text_column=self.text_column,
         )

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -360,6 +360,10 @@ class AwqQuantizer:
             scales = scales / (scales.max() * scales.min()).sqrt()
             scales_view = scales.view(1, -1).to(device)
 
+            # avoid scaling values that overflow
+            scales[torch.isinf(scales)] = 1
+            scales[torch.isnan(scales)] = 1
+
             # Q(W * s)
             for fc in linears2scale:
                 fc.weight.mul_(scales_view)

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -245,12 +245,13 @@ class AwqQuantizer:
             module_output = []
             for i in range(0, x.shape[0], self.n_calib_samples):
                 x_partial = x[i : i + self.n_calib_samples]
-                fp16_partial_output = module(x_partial, **module_kwargs)
-                module_output.append(
-                    fp16_partial_output[0]
-                    if isinstance(module_output, tuple)
-                    else fp16_partial_output
-                )
+                partial_output = module(x_partial, **module_kwargs)
+
+                if isinstance(partial_output, tuple):
+                    partial_output = partial_output[0]
+
+                module_output.append(partial_output)
+
             module_output = torch.cat(module_output, dim=0)
 
         return module_output

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -232,7 +232,7 @@ class AwqQuantizer:
 
     @torch.no_grad()
     def _module_forward(
-        self, x: torch.Tensor, module: torch.Module, module_kwargs: Dict
+        self, x: torch.Tensor, module: torch.nn.Module, module_kwargs: Dict
     ) -> torch.Tensor:
         if self.n_calib_samples is None:
             # runs through all samples at once

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -42,6 +42,8 @@ class AwqQuantizer:
         export_compatible=False,
         apply_clip=True,
         n_calib_samples=None,
+        max_calib_samples=128,
+        max_calib_seq_len=512,
     ) -> None:
         self.awq_model = awq_model
         self.model = model
@@ -57,10 +59,15 @@ class AwqQuantizer:
         self.export_compatible = export_compatible
         self.apply_clip = apply_clip
         self.n_calib_samples = n_calib_samples
+        self.max_calib_samples = max_calib_samples
+        self.max_calib_seq_len = max_calib_seq_len
         self.modules_to_not_convert = (
             modules_to_not_convert if modules_to_not_convert is not None else []
         )
-        self.modules, self.module_kwargs, self.inps = self.init_quant()
+        self.modules, self.module_kwargs, self.inps = self.init_quant(
+            n_samples=self.max_calib_samples,
+            max_seq_len=self.max_calib_seq_len
+        )
 
     def pseudo_quantize_tensor(self, w: torch.Tensor):
         org_w_shape = w.shape

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -44,6 +44,7 @@ class AwqQuantizer:
         n_parallel_calib_samples=None,
         max_calib_samples=128,
         max_calib_seq_len=512,
+        max_chunk_memory=1024 * 1024 * 1024,
     ) -> None:
         self.awq_model = awq_model
         self.model = model
@@ -61,7 +62,7 @@ class AwqQuantizer:
         self.n_parallel_calib_samples = n_parallel_calib_samples
         self.max_calib_samples = max_calib_samples
         self.max_calib_seq_len = max_calib_seq_len
-        self.max_chunk_memory = 1024 * 1024 * 1024
+        self.max_chunk_memory = max_chunk_memory
         self.modules_to_not_convert = (
             modules_to_not_convert if modules_to_not_convert is not None else []
         )
@@ -429,7 +430,7 @@ class AwqQuantizer:
         int_w_chunks = torch.split(int_w_output_flat, chunk_size)
 
         # Compute the loss for each chunk
-        for fp16_chunk, int_w_chunk in zip(fp16_chunks, int_w_chunks):
+        for fp16_chunk, int_w_chunk in tqdm(zip(fp16_chunks, int_w_chunks), total=len(fp16_chunks), desc="Computing Loss", leave=False):
             chunk_loss = (fp16_chunk - int_w_chunk).float().pow(2).sum().item()
             loss += chunk_loss
 

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -67,8 +67,7 @@ class AwqQuantizer:
             modules_to_not_convert if modules_to_not_convert is not None else []
         )
         self.modules, self.module_kwargs, self.inps = self.init_quant(
-            n_samples=self.max_calib_samples,
-            max_seq_len=self.max_calib_seq_len
+            n_samples=self.max_calib_samples, max_seq_len=self.max_calib_seq_len
         )
 
     def pseudo_quantize_tensor(self, w: torch.Tensor):
@@ -253,7 +252,9 @@ class AwqQuantizer:
             # but only n_parallel_calib_samples at a time
             module_output = []
             partitioned_inputs = torch.split(x, self.n_parallel_calib_samples)
-            for x_partial in tqdm(partitioned_inputs, desc="Module forward", leave=False):
+            for x_partial in tqdm(
+                partitioned_inputs, desc="Module forward", leave=False
+            ):
                 partial_output = module(x_partial, **module_kwargs)
 
                 if isinstance(partial_output, tuple):
@@ -305,7 +306,7 @@ class AwqQuantizer:
         num_elements = inp_flat.size(0)
         num_channels = inp_flat.size(1)
         element_size_bytes = inp_flat.element_size()
-        
+
         # Calculate chunk size dynamically based on max_chunk_memory
         chunk_size = self.max_chunk_memory // (element_size_bytes * num_channels)
         chunk_size = min(chunk_size, num_elements)
@@ -430,7 +431,12 @@ class AwqQuantizer:
         int_w_chunks = torch.split(int_w_output_flat, chunk_size)
 
         # Compute the loss for each chunk
-        for fp16_chunk, int_w_chunk in tqdm(zip(fp16_chunks, int_w_chunks), total=len(fp16_chunks), desc="Computing Loss", leave=False):
+        for fp16_chunk, int_w_chunk in tqdm(
+            zip(fp16_chunks, int_w_chunks),
+            total=len(fp16_chunks),
+            desc="Computing Loss",
+            leave=False,
+        ):
             chunk_loss = (fp16_chunk - int_w_chunk).float().pow(2).sum().item()
             loss += chunk_loss
 
@@ -438,7 +444,6 @@ class AwqQuantizer:
         loss /= num_elements
 
         return loss
-
 
     @torch.no_grad()
     def _search_best_clip(self, layer, named_linears, input_feat):

--- a/awq/utils/calib_data.py
+++ b/awq/utils/calib_data.py
@@ -7,8 +7,8 @@ from datasets import load_dataset
 def get_calib_dataset(
     data: Union[str, List[str], List[List[int]]] = "pileval",
     tokenizer=None,
-    n_samples=512,
-    block_size=512,
+    n_samples=128,
+    max_seq_len=512,
     split="train",
     text_column="text",
 ):
@@ -47,7 +47,7 @@ def get_calib_dataset(
             line = data[text_column]
             line = line.strip()
             line_encoded = tokenizer.encode(line)
-        if len(line_encoded) > 512:
+        if len(line_encoded) > max_seq_len:
             continue
         sample = torch.tensor([line_encoded])
         if sample.numel() == 0:
@@ -56,10 +56,10 @@ def get_calib_dataset(
         n_run += 1
         if n_run == n_samples:
             break
-    # now concatenate all samples and split according to block size
+    # now concatenate all samples and split according to max sequence length
     cat_samples = torch.cat(samples, dim=1)
-    n_split = cat_samples.shape[1] // block_size
+    n_split = cat_samples.shape[1] // max_seq_len
     logging.debug(f" * Split into {n_split} blocks")
     return [
-        cat_samples[:, i * block_size : (i + 1) * block_size] for i in range(n_split)
+        cat_samples[:, i * max_seq_len : (i + 1) * max_seq_len] for i in range(n_split)
     ]

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -145,7 +145,7 @@ from transformers import AutoTokenizer
 
 model_path = 'deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct'
 quant_path = 'deepseek-coder-v2-lite-instruct-awq'
-quant_config = { "zero_point": True, "q_group_size": 128, "w_bit": 4, "version": "GEMM" }
+quant_config = { "zero_point": True, "q_group_size": 64, "w_bit": 4, "version": "GEMM" }
 
 # Load model
 model = AutoAWQForCausalLM.from_pretrained(
@@ -168,9 +168,10 @@ model.quantize(
     tokenizer,
     quant_config=quant_config,
     calib_data=load_openhermes_coding(),
-    n_parallel_calib_samples=32,
-    max_calib_samples=128,
-    max_calib_seq_len=4096
+    # MODIFY these parameters if need be:
+    # n_parallel_calib_samples=32,
+    # max_calib_samples=128,
+    # max_calib_seq_len=4096
 )
 
 # Save quantized model

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -78,14 +78,22 @@ tokenizer.save_pretrained(quant_path)
 print(f'Model is quantized and saved at "{quant_path}"')
 ```
 
-#### Long-context and thousands of calibration samples
+#### Long-context: Optimizing quantization
 
 For this example, we will use HuggingFaceTB/cosmopedia-100k as it's a high-quality dataset and
 we can filter directly on the number of tokens. We will use Qwen2 7B, one of the newer supported
-models in AutoAWQ which is high-performing.
+models in AutoAWQ which is high-performing. The following example ran smoothly on a machine with
+an RTX 4090 24 GB VRAM with 107 GB system RAM.
 
-NOTE: Please make sure to properly adjust `n_parallel_calib_samples` to avoid OOM. If your sequence
-length is long and you have many samples, it's very important to tune this parameter to avoid OOM.
+NOTE: Adjusting `n_parallel_calib_samples`, `max_calib_samples`, and `max_calib_seq_len` will help
+avoid OOM when customizing your dataset.
+
+- The AWQ algorithm is incredibly sample efficient, so `max_calib_samples` of 128-256 should be
+sufficient to quantize a model. A higher number of samples may not be possible without significant
+memory available or without further optimizing AWQ with a PR for disk offload.
+- When `n_parallel_calib_samples` is set to an integer, we offload to system RAM to save GPU VRAM.
+This may cause OOM on your system if you have little memory available; we are looking to optimize
+this further in future versions.
 
 ```python
 from datasets import load_dataset
@@ -114,7 +122,7 @@ model.quantize(
     quant_config=quant_config,
     calib_data=load_cosmopedia(),
     n_parallel_calib_samples=32,
-    max_calib_samples=1000,
+    max_calib_samples=128,
     max_calib_seq_len=4096
 )
 


### PR DESCRIPTION
TODO:
- [x] Add documentation with custom dataset, e.g. Cosmopedia filtering for long samples only.

Features:
- Split samples into batches of `n_parallel_calib_samples`
- Allow any sample length (long context)

Fixes:
- If you modify `n_samples` to be higher than 128, OOM is extremely likely because all samples are currently run through the model at the same time. Closes #517 #493
- `scales` being NaN or inf in some cases. Resolves #498 #500 #509.