### PR TITLE
Expose calibration dataset arguments

### DIFF
--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -155,6 +155,18 @@ class BaseAWQForCausalLM(nn.Module):
                 "Whether to apply clipping to the model during quantization. Some models may perform better with this set to False."
             ),
         ] = True,
+        n_samples: Annotated[
+            int,
+            Doc(
+                "Number of samples to use in calibration dataset."
+            ),
+        ] = 128,
+        seqlen: Annotated[
+            int,
+            Doc(
+                "Sequence length of the calibration examples."
+            ),
+        ] = 512,
     ):
         """
         The main quantization function that you can use to quantize your model.
@@ -193,6 +205,8 @@ class BaseAWQForCausalLM(nn.Module):
             modules_to_not_convert=self.quant_config.modules_to_not_convert,
             export_compatible=export_compatible,
             apply_clip=apply_clip,
+            n_samples=n_samples,
+            seqlen=seqlen,
         )
         self.quantizer.quantize()
 

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -41,6 +41,8 @@ class AwqQuantizer:
         modules_to_not_convert=None,
         export_compatible=False,
         apply_clip=True,
+        n_samples=128,
+        seqlen=512,
     ) -> None:
         self.awq_model = awq_model
         self.model = model
@@ -58,7 +60,10 @@ class AwqQuantizer:
         self.modules_to_not_convert = (
             modules_to_not_convert if modules_to_not_convert is not None else []
         )
-        self.modules, self.module_kwargs, self.inps = self.init_quant()
+        self.modules, self.module_kwargs, self.inps = self.init_quant(
+            n_samples=n_samples,
+            seqlen=seqlen,
+        )
 
     def pseudo_quantize_tensor(self, w: torch.Tensor):
         org_w_shape = w.shape


### PR DESCRIPTION
This PR exposes the arguments `n_samples` and `seqlen` to make it possible to use sequences longer than 512 tokens.