### PR TITLE
nan problem of Qwen2-72B quantization 

### DIFF
--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -256,7 +256,7 @@ class AwqQuantizer:
         weight = weight.view(-1, self.group_size)
         # Calculates the relative magnitude of the weights within each of the quantization groups, 
         # and rescales each group individually so that each group has weights on a 0-1 scale.
-        w_scale = weight.abs() / weight.abs().amax(dim=1, keepdim=True)
+        w_scale = weight.abs() / (weight.abs().amax(dim=1, keepdim=True) + 1e-6)
         # Resizes the rescaled weight matrix back up to its original dimensions
         w_scale = w_scale.view(org_shape)
         # Gets the average rescaled magnitude for each output channel


### PR DESCRIPTION
change weight scaling formulation, fix nan problem when quantize Qwen2-72B model

For #498 ,  casper-hansen #516  and Qwen team https://github.com/yangyo/AutoAWQ/commit/32bf03c3067c5d863a6c7151861f6f954435317d?diff=split&w=1 fix this problem by set nan or inf to 1 to walkaround it, But I think this is unreasonble.

I found the occurence of nan was caused by the process of weight scaling, where part of some weights like mlp.gate_proj, mlp.up_proj exceed the range of float16. So those weights become to 0 when loading model.  The nans occur when cacluating 0/0.  Add some small value to denominator can solve this problem.