### PR TITLE
Qwen nan fix

### DIFF
--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -322,7 +322,7 @@ class AwqQuantizer:
 
             # NOTE: s^-1 * x is fused here, according to paper
             if self.duo_scaling:
-                scales = (x_mean.pow(ratio) / w_mean.pow(1 - ratio)).clamp(min=1e-4)
+                scales = (x_mean.pow(ratio) / (w_mean.pow(1 - ratio) + 1e-4)).clamp(min=1e-4)
             else:
                 scales = x_mean.pow(ratio).clamp(min=1e-4).view(-1)
             scales = scales / (scales.max() * scales.min()).sqrt()


### PR DESCRIPTION
After quantization, Qwen2-72B can not inference using multi gpu with vllm, so we need to pad intermediate_size from 29568 to 29696 with zeros. But after padding, the nan problem occurs again. This commit fix it.

The details can be found in https://github.com/QwenLM/Qwen2/issues/578,  it's found in GPTQ, but also occurs in AWQ.