### PR TITLE
fix deepseek v2 input feat

### DIFF
--- a/awq/models/deepseek_v2.py
+++ b/awq/models/deepseek_v2.py
@@ -48,7 +48,7 @@ class DeepseekV2AWQForCausalLM(BaseAWQForCausalLM):
                         module.self_attn.q_a_proj,
                         module.self_attn.kv_a_proj_with_mqa,
                     ],
-                    inp=input_feat["self_attn.q_proj"],
+                    inp=input_feat["self_attn.q_a_proj"],
                     module2inspect=module.self_attn,
                     kwargs=module_kwargs,
                 )


### PR DESCRIPTION
There is a slight difference in the query calculation between DeepSeek-Coder-V2 and DeepSeek-Coder-V2-Lite, resulting in https://github.com/casper-hansen/AutoAWQ/pull/508#issuecomment-2194385570. Fix a minor variable misuse.