### PR TITLE
Fix fp16 overflow

### DIFF
--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -391,10 +391,11 @@ class AwqQuantizer:
                 # avoid scaling values that overflow
                 scales[torch.isinf(scales)] = 1
                 scales[torch.isnan(scales)] = 1
+                for fc in linears2scale:
+                    scales_view[torch.isinf(fc.weight.mul(scales_view)).sum(dim=0).unsqueeze(0) > 0] = 1
 
                 # Q(W * s)
                 for fc in linears2scale:
-                    scales_view[torch.isinf(fc.weight.mul(scales_view)).sum(dim=0).unsqueeze(0) > 0] = 1
                     fc.weight.mul_(scales_view)
                     fc.weight.data = (
                         self.pseudo_quantize_tensor(fc.weight.data)[0] / scales_view


### PR DESCRIPTION
Try to fix the precision problems of fp16.
The previous PRs fixed some cases like division by 0, but it may still report an error when the maximum range of fp16 is exceeded, such as the overflow of the value after weight scaling. Here we try to modify two places:
1. Cancel scaling when overflow
2. Convert the calculation of `pseudo_quantize_tensor` to fp32

(However I doubt whether this extreme case will actually occur, as model may not work at all under fp16 at this time)