### PR TITLE
fix: pass rope_theta argument when initializing LlamaLikeBlock for models like qwen2, mistral, etc.

### DIFF
--- a/awq/models/aquila.py
+++ b/awq/models/aquila.py
@@ -127,6 +127,7 @@ class AquilaFuser:
                     norm_2=norm_2,
                     dev=device,
                     max_seq_len=self.model.config.max_seq_len,
+                    rope_theta=self.model.config.rope_theta,
                 )
             )
 

--- a/awq/models/llava.py
+++ b/awq/models/llava.py
@@ -133,6 +133,7 @@ class LlavaFuser:
                     norm_2=norm_2,
                     dev=device,
                     max_seq_len=max_seq_len,
+                    rope_theta=self.model.config.rope_theta,
                 )
             )
 

--- a/awq/models/llava_next.py
+++ b/awq/models/llava_next.py
@@ -130,6 +130,7 @@ class LlavaNextFuser:
                     norm_2=norm_2,
                     dev=device,
                     max_seq_len=max_seq_len,
+                    rope_theta=self.model.config.rope_theta,
                 )
             )
 

--- a/awq/models/mistral.py
+++ b/awq/models/mistral.py
@@ -127,6 +127,7 @@ class MistralFuser:
                     norm_2=norm_2,
                     dev=device,
                     max_seq_len=self.model.config.max_seq_len,
+                    rope_theta=self.model.config.rope_theta,
                 )
             )
 

--- a/awq/models/qwen2.py
+++ b/awq/models/qwen2.py
@@ -125,6 +125,7 @@ class Qwen2Fuser:
                     norm_2=norm_2,
                     dev=device,
                     max_seq_len=self.model.config.max_seq_len,
+                    rope_theta=self.model.config.rope_theta,
                 )
             )
 

--- a/awq/models/starcoder2.py
+++ b/awq/models/starcoder2.py
@@ -125,6 +125,7 @@ class Starcoder2Fuser:
                     norm_2=norm_2,
                     dev=device,
                     max_seq_len=self.model.config.max_seq_len,
+                    rope_theta=self.model.config.rope_theta,
                 )
             )
 


### PR DESCRIPTION
This PR aims to fix this issue https://github.com/casper-hansen/AutoAWQ/issues/567.

```python
    def fuse_transformer(self):
            ...
            blocks.append(
                LlamaLikeBlock(
                    hidden_size=self.model.config.hidden_size,
                    n_heads=self.model.config.num_attention_heads,
                    n_kv_heads=self.model.config.num_key_value_heads,
                    qkv_layer=qkv,
                    o_proj=module.self_attn.o_proj,
                    mlp=module.mlp,
                    norm_1=norm_1,
                    norm_2=norm_2,
                    dev=device,
                    max_seq_len=self.model.config.max_seq_len,
                    rope_theta=self.model.config.rope_theta,                # only add this line.
                )
            )
```