### PR TITLE
Let installed PyTorch decide required version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ def get_kernels_whl_url(
 AUTOAWQ_VERSION = "0.2.6"
 PYPI_BUILD = os.getenv("PYPI_BUILD", "0") == "1"
 IS_CPU_ONLY = not torch.backends.mps.is_available() and not torch.cuda.is_available()
+TORCH_VERSION = str(os.getenv("TORCH_VERSION", None) or torch.__version__).split('+', maxsplit=1)[0]
 
 CUDA_VERSION = os.getenv("CUDA_VERSION", None) or torch.version.cuda
 if CUDA_VERSION:
@@ -86,7 +87,7 @@ common_setup_kwargs = {
 }
 
 requirements = [
-    "torch==2.3.1",
+    f"torch=={TORCH_VERSION}",
     "transformers>=4.35.0",
     "tokenizers>=0.12.1",
     "typing_extensions>=4.8.0",


### PR DESCRIPTION
Related to [AWQ_kernels's PR#29](https://github.com/casper-hansen/AutoAWQ_kernels/pull/29) to let installed PyTorch version decide which is the required version.

Without it, I was able to build the kernels from source using CUDA 12.5 and PyTorch 2.4.0 but trying to install AWQ from source on Python 3.12.4 would downgrade torch and therefor prevent installation.

Once the kernels are built and installed, install AWQ from source using the following command to avoid downgrading pytorch.
```
pip install --no-build-isolation "git+https://github.com/wasertech/AutoAWQ.git@py312-torch240-cu124"
```