### PR TITLE
Add Internlm2 support

### DIFF
--- a/awq/models/__init__.py
+++ b/awq/models/__init__.py
@@ -23,3 +23,4 @@ from .phi3 import Phi3AWQForCausalLM
 from .cohere import CohereAWQForCausalLM
 from .deepseek_v2 import DeepseekV2AWQForCausalLM
 from .minicpm import MiniCPMAWQForCausalLM
+from .internlm2 import InternLM2AWQForCausalLM

--- a/awq/models/auto.py
+++ b/awq/models/auto.py
@@ -33,6 +33,7 @@ AWQ_CAUSAL_LM_MODEL_MAP = {
     "cohere": CohereAWQForCausalLM,
     "deepseek_v2": DeepseekV2AWQForCausalLM,
     "minicpm": MiniCPMAWQForCausalLM,
+    "internlm2": InternLM2AWQForCausalLM,
 }
 
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -84,6 +84,7 @@ TRANSFORMERS_AUTO_MAPPING_DICT = {
     "cohere": "AutoModelForCausalLM",
     "deepseek_v2": "AutoModelForCausalLM",
     "minicpm": "AutoModelForCausalLM",
+    "internlm2": "AutoModelForCausalLM",
 }
 
 

--- a/awq/models/internlm2.py
+++ b/awq/models/internlm2.py
@@ -1,0 +1,76 @@
+import tqdm
+from typing import List, Tuple
+from .base import BaseAWQForCausalLM
+
+
+class InternLM2AWQForCausalLM(BaseAWQForCausalLM):
+    layer_type = "InternLM2DecoderLayer"
+    max_seq_len_key = "max_position_embeddings"
+
+    @staticmethod
+    def get_model_layers(model):
+        return model.model.layers
+
+    @staticmethod
+    def get_act_for_scaling(module):
+        return dict(
+            is_scalable=True,
+            scale_name="feed_forward.w2",
+            scale_layer=module.feed_forward.w2,
+            scale_shape=module.feed_forward.w2.out_features,
+        )
+
+    @staticmethod
+    def move_embed(model, device: str):
+        model.model.tok_embeddings = model.model.tok_embeddings.to(device)
+
+    @staticmethod
+    def get_layers_for_scaling(module, input_feat, module_kwargs):
+        layers = []
+
+        # attention input
+        layers.append(
+            dict(
+                prev_op=module.attention_norm,
+                layers=[
+                    module.attention.wqkv,
+                ],
+                inp=input_feat["attention.wqkv"],
+                module2inspect=module.attention,
+                kwargs=module_kwargs,
+            )
+        )
+
+        # attention out
+        layers.append(
+            dict(
+                prev_op=module.attention.wqkv,
+                layers=[module.attention.wo],
+                inp=input_feat["attention.wo"],
+            )
+        )
+
+        # feed forward input
+        layers.append(
+            dict(
+                prev_op=module.ffn_norm,
+                layers=[
+                    module.feed_forward.w1,
+                    module.feed_forward.w3,
+                ],
+                inp=input_feat["feed_forward.w1"],
+                module2inspect=module.feed_forward,
+                kwargs=module_kwargs,
+            )
+        )
+
+        # feed forward output
+        layers.append(
+            dict(
+                prev_op=module.feed_forward.w1,
+                layers=[module.feed_forward.w2],
+                inp=input_feat["feed_forward.w2"],
+            )
+        )
+
+        return layers

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,9 @@ requirements = [
     "accelerate",
     "datasets",
     "zstandard",
+    "einops",
+    "protobuf",
+    "sentencepiece",
 ]
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -93,9 +93,6 @@ requirements = [
     "accelerate",
     "datasets",
     "zstandard",
-    "einops",
-    "protobuf",
-    "sentencepiece",
 ]
 
 try:


### PR DESCRIPTION
This pull request implements support for InterLM2 in AutoAWQ. The integration has been successfully tested and generates high-quality output.

**Changes include:**

    Added InterLM2 configurations to:
        models/init.py
        models/auto.py
        models/base.py

    Created a new file_: models/internlm2.py

    Updated setup.py to include additional dependencies:
        protobuf
        sentencepiece
        einops

Note: If there's a more efficient way to manage model-specific dependencies, it might be preferable to the current approach of adding them to the global requirements.
