### PR TITLE
Added support for minicpmv2.6. 

### DIFF
--- a/awq/models/__init__.py
+++ b/awq/models/__init__.py
@@ -23,3 +23,4 @@ from .phi3 import Phi3AWQForCausalLM
 from .cohere import CohereAWQForCausalLM
 from .deepseek_v2 import DeepseekV2AWQForCausalLM
 from .minicpm import MiniCPMAWQForCausalLM
+from .minicpmv import MiniCPMVAWQForCausalLM

--- a/awq/models/auto.py
+++ b/awq/models/auto.py
@@ -33,6 +33,7 @@ AWQ_CAUSAL_LM_MODEL_MAP = {
     "cohere": CohereAWQForCausalLM,
     "deepseek_v2": DeepseekV2AWQForCausalLM,
     "minicpm": MiniCPMAWQForCausalLM,
+    "minicpmv": MiniCPMVAWQForCausalLM
 }
 
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -84,6 +84,7 @@ TRANSFORMERS_AUTO_MAPPING_DICT = {
     "cohere": "AutoModelForCausalLM",
     "deepseek_v2": "AutoModelForCausalLM",
     "minicpm": "AutoModelForCausalLM",
+    "minicpmv":"AutoModelForCausalLM"
 }
 
 

--- a/awq/models/minicpmv.py
+++ b/awq/models/minicpmv.py
@@ -1,0 +1,243 @@
+import tqdm
+from typing import List, Tuple
+from .base import BaseAWQForCausalLM
+from awq.utils.fused_utils import fuse_qkv
+from awq.modules.fused.block import LlamaLikeBlock
+from awq.modules.fused.model import LlamaLikeModel
+from transformers.models.llama.modeling_llama import (
+    LlamaDecoderLayer as OldLlamaDecoderLayer,
+)
+from transformers.models.qwen2.modeling_qwen2 import (
+    Qwen2DecoderLayer as OldQwen2DecoderLayer,
+    Qwen2ForCausalLM as OldQwen2ForCausalLM,
+)
+
+from transformers.models.llava.modeling_llava import (
+    LlavaForConditionalGeneration as OldLlavaForConditionalGeneration,
+)
+from awq.modules.fused.norm import FasterTransformerRMSNorm
+import torch
+from transformers import AutoProcessor
+import json
+from copy import deepcopy
+from PIL import Image
+from awq.modules.fused.attn import QuantAttentionFused
+from torch import nn
+from awq.utils import fused_utils
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast
+)
+from awq.modules.fused.block import (
+    LlamaLikeBlock,
+)
+
+class MiniCPMVAWQForCausalLM(BaseAWQForCausalLM):
+    layer_type = "Qwen2DecoderLayer"
+    max_seq_len_key = "max_position_embeddings"
+
+    def chat(
+        self,
+        image,
+        msgs,
+        tokenizer,
+        processor=None,
+        vision_hidden_states=None,
+        max_new_tokens=2048,
+        min_new_tokens=0,
+        sampling=True,
+        max_inp_length=8192,
+        system_prompt='',
+        stream=False,
+        max_slice_nums=None,
+        use_image_id=None,
+        **kwargs
+    ):
+        if isinstance(msgs[0], list):
+            batched = True
+        else:
+            batched = False
+        msgs_list = msgs
+        images_list = image
+        
+        if batched is False:
+            images_list, msgs_list = [images_list], [msgs_list]
+        else:
+            assert images_list is None, "Please integrate image to msgs when using batch inference."
+            images_list = [None] * len(msgs_list)
+        assert len(images_list) == len(msgs_list), "The batch dim of images_list and msgs_list should be the same."
+
+        if processor is None:
+            if self.processor is None:
+                self.processor = AutoProcessor.from_pretrained(self.config._name_or_path, trust_remote_code=True)
+            processor = self.processor
+        
+        assert self.config.query_num == processor.image_processor.image_feature_size, "These two values should be the same. Check `config.json` and `preprocessor_config.json`."
+        assert self.config.patch_size == processor.image_processor.patch_size, "These two values should be the same. Check `config.json` and `preprocessor_config.json`."
+        assert self.config.use_image_id == processor.image_processor.use_image_id, "These two values should be the same. Check `config.json` and `preprocessor_config.json`."
+        assert self.config.slice_config.max_slice_nums == processor.image_processor.max_slice_nums, "These two values should be the same. Check `config.json` and `preprocessor_config.json`."
+        assert self.config.slice_mode == processor.image_processor.slice_mode, "These two values should be the same. Check `config.json` and `preprocessor_config.json`."
+
+        prompts_lists = []
+        input_images_lists = []
+        for image, msgs in zip(images_list, msgs_list):
+            if isinstance(msgs, str):
+                msgs = json.loads(msgs)
+            copy_msgs = deepcopy(msgs)
+
+            assert len(msgs) > 0, "msgs is empty"
+            assert sampling or not stream, "if use stream mode, make sure sampling=True"
+
+            if image is not None and isinstance(copy_msgs[0]["content"], str):
+                copy_msgs[0]["content"] = [image, copy_msgs[0]["content"]]
+
+            images = []
+            for i, msg in enumerate(copy_msgs):
+                role = msg["role"]
+                content = msg["content"]
+                assert role in ["user", "assistant"]
+                if i == 0:
+                    assert role == "user", "The role of first msg should be user"
+                if isinstance(content, str):
+                    content = [content]
+                cur_msgs = []
+                for c in content:
+                    if isinstance(c, Image.Image):
+                        images.append(c)
+                        cur_msgs.append("(<image>./</image>)")
+                    elif isinstance(c, str):
+                        cur_msgs.append(c)
+                msg["content"] = "\n".join(cur_msgs)
+
+            if system_prompt:
+                sys_msg = {'role': 'system', 'content': system_prompt}
+                copy_msgs = [sys_msg] + copy_msgs        
+
+            prompts_lists.append(processor.tokenizer.apply_chat_template(copy_msgs, tokenize=False, add_generation_prompt=True))
+            input_images_lists.append(images)
+
+        inputs = processor(
+            prompts_lists, 
+            input_images_lists, 
+            max_slice_nums=max_slice_nums,
+            use_image_id=use_image_id,
+            return_tensors="pt", 
+            max_length=max_inp_length
+        ).to('cuda:0')
+
+        if sampling:
+            generation_config = {
+                "top_p": 0.8,
+                "top_k": 100,
+                "temperature": 0.7,
+                "do_sample": True,
+                "repetition_penalty": 1.05
+            }
+        else:
+            generation_config = {
+                "num_beams": 3,
+                "repetition_penalty": 1.2,
+            }
+            
+        if min_new_tokens > 0:
+            generation_config['min_new_tokens'] = min_new_tokens
+
+        generation_config.update(
+            (k, kwargs[k]) for k in generation_config.keys() & kwargs.keys()
+        )
+
+        inputs.pop("image_sizes")
+        with torch.inference_mode():
+            res = self.generate(
+                **inputs,
+                tokenizer=tokenizer,
+                max_new_tokens=max_new_tokens,
+                vision_hidden_states=vision_hidden_states,
+                stream=stream,
+                decode_text=True,
+                **generation_config
+            )
+        
+        if stream:
+            def stream_gen():
+                for text in res:
+                    for term in self.terminators:
+                        text = text.replace(term, '')
+                    yield text
+            return stream_gen()
+
+        else:
+            if batched:
+                answer = res
+            else:
+                answer = res[0]
+            return answer
+    # @staticmethod
+    # def fuse_layers(model: OldQwen2ForCausalLM):
+    #     fuser = MiniCPMVFuser(model) # 这里是算子融合
+    #     fuser.fuse_transformer()
+
+    @staticmethod
+    def get_model_layers(model: OldQwen2ForCausalLM):
+        return model.llm.model.layers
+
+    @staticmethod
+    def get_act_for_scaling(module:  OldQwen2DecoderLayer):
+        return dict(is_scalable=False)
+
+    @staticmethod
+    def move_embed(model: OldQwen2DecoderLayer, device: str):
+        model.llm.model.embed_tokens = model.get_input_embeddings().to(
+            device
+        )
+
+    @staticmethod
+    def get_layers_for_scaling(module: OldQwen2DecoderLayer, input_feat, module_kwargs):
+        layers = []
+
+        # attention input
+        layers.append(
+            dict(
+                prev_op=module.input_layernorm,
+                layers=[
+                    module.self_attn.q_proj,
+                    module.self_attn.k_proj,
+                    module.self_attn.v_proj,
+                ],
+                inp=input_feat["self_attn.q_proj"],
+                module2inspect=module.self_attn,
+                kwargs=module_kwargs,
+            )
+        )
+
+        # attention out
+        # Please refer to https://github.com/mit-han-lab/llm-awq/pull/67#issue-1850622696
+        if module.self_attn.v_proj.weight.shape == module.self_attn.o_proj.weight.shape:
+            layers.append(
+                dict(
+                    prev_op=module.self_attn.v_proj,
+                    layers=[module.self_attn.o_proj],
+                    inp=input_feat["self_attn.o_proj"],
+                )
+            )
+
+        # linear 1
+        layers.append(
+            dict(
+                prev_op=module.post_attention_layernorm,
+                layers=[module.mlp.gate_proj, module.mlp.up_proj],
+                inp=input_feat["mlp.gate_proj"],
+                module2inspect=module.mlp,
+            )
+        )
+
+        # linear 2
+        layers.append(
+            dict(
+                prev_op=module.mlp.up_proj,
+                layers=[module.mlp.down_proj],
+                inp=input_feat["mlp.down_proj"],
+            )
+        )
+
+        return layers
+


### PR DESCRIPTION
Added support for minicpmv2.6. If you only infer the awq quantification model of minicpmv, you can use it directly. However, if you need to quantify minicpmv2.6, you need to replace the current minicpmv modeling file with the following [file](https://github.com/LDLINGLINGLING/MiniCPM_Series_Tutorial/blob/main/MiniCPMV2_6_awq/modeling_minicpmv.py). This is mainly because minicpmv2.6 has not yet opened the interface for plain text input.
