### PR TITLE
quantization fails with old `datasets`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ requirements = [
     "tokenizers>=0.12.1",
     "typing_extensions>=4.8.0",
     "accelerate",
-    "datasets",
+    "datasets>=2.20",
     "zstandard",
 ]
 


### PR DESCRIPTION
with `datasets==2.14.4` quantization fails:
```
  File "/env/lib/conda/stas-inference/lib/python3.10/site-packages/datasets/data_files.py", line 332, in resolve_pattern
    fs, _, _ = get_fs_token_paths(pattern, storage_options=storage_options)
  File "/env/lib/conda/stas-inference/lib/python3.10/site-packages/fsspec/core.py", line 681, in get_fs_token_paths
    paths = [f for f in sorted(fs.glob(paths)) if not fs.isdir(f)]
  File "/env/lib/conda/stas-inference/lib/python3.10/site-packages/huggingface_hub/hf_file_system.py", line 417, in glob
    return super().glob(path, **kwargs)
  File "/env/lib/conda/stas-inference/lib/python3.10/site-packages/fsspec/spec.py", line 613, in glob
    pattern = glob_translate(path + ("/" if ends_with_sep else ""))
  File "/env/lib/conda/stas-inference/lib/python3.10/site-packages/fsspec/utils.py", line 732, in glob_translate
    raise ValueError(
ValueError: Invalid pattern: '**' can only be an entire path component
```

I'm not sure what's the earliest minimal version that works, but I tested it to work with `datasets==2.20.0` and `datasets==2.21.0`.
