### PR TITLE
fix for "two devices" issue due to RoPE changes

### DIFF
--- a/awq/models/cohere.py
+++ b/awq/models/cohere.py
@@ -29,6 +29,7 @@ class CohereAWQForCausalLM(BaseAWQForCausalLM):
 
     @staticmethod
     def move_embed(model: OldCohereForCausalLM, device: str):
+        model.model.rotary_emb = model.model.rotary_emb.to(device)
         model.model.embed_tokens = model.model.embed_tokens.to(device)
 
     @staticmethod

--- a/awq/models/gpt_neox.py
+++ b/awq/models/gpt_neox.py
@@ -24,6 +24,7 @@ class GPTNeoXAWQForCausalLM(BaseAWQForCausalLM):
 
     @staticmethod
     def move_embed(model: GPTNeoXForCausalLM, device: str):
+        model.gpt_neox.rotary_emb = model.gpt_neox.rotary_emb.to(device)
         model.gpt_neox.embed_in = model.gpt_neox.embed_in.to(device)
 
     @staticmethod

--- a/awq/models/llama.py
+++ b/awq/models/llama.py
@@ -30,6 +30,7 @@ class LlamaAWQForCausalLM(BaseAWQForCausalLM):
 
     @staticmethod
     def move_embed(model: OldLlamaForCausalLM, device: str):
+        model.model.rotary_emb = model.model.rotary_emb.to(device)
         model.model.embed_tokens = model.model.embed_tokens.to(device)
 
     @staticmethod

--- a/awq/models/qwen2.py
+++ b/awq/models/qwen2.py
@@ -30,6 +30,7 @@ class Qwen2AWQForCausalLM(BaseAWQForCausalLM):
 
     @staticmethod
     def move_embed(model: OldQwen2ForCausalLM, device: str):
+        model.model.rotary_emb = model.model.rotary_emb.to(device)
         model.model.embed_tokens = model.model.embed_tokens.to(device)
 
     @staticmethod

--- a/awq/models/stablelm.py
+++ b/awq/models/stablelm.py
@@ -30,6 +30,7 @@ class StableLmAWQForCausalLM(BaseAWQForCausalLM):
 
     @staticmethod
     def move_embed(model: OldStableLmForCausalLM, device: str):
+        model.model.rotary_emb = model.model.rotary_emb.to(device)
         model.model.embed_tokens = model.model.embed_tokens.to(device)
 
     @staticmethod

--- a/awq/models/starcoder2.py
+++ b/awq/models/starcoder2.py
@@ -36,6 +36,7 @@ class Starcoder2AWQForCausalLM(BaseAWQForCausalLM):
 
     @staticmethod
     def move_embed(model: OldStarcoder2ForCausalLM, device):
+        model.model.rotary_emb = model.model.rotary_emb.to(device)
         model.model.embed_tokens = model.model.embed_tokens.to(device)
 
     @staticmethod

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -542,6 +542,7 @@ class AwqQuantizer:
         best_device = get_best_device()
         modules[0] = modules[0].to(best_device)
         self.awq_model.move_embed(self.model, best_device)
+        self.awq_model.model.model.rotary_emb.to(best_device)
 
         # get input and kwargs to layer 0
         # with_kwargs is only supported in PyTorch 2.0
@@ -583,6 +584,7 @@ class AwqQuantizer:
 
         modules[0] = modules[0].cpu()
         self.awq_model.move_embed(self.model, "cpu")
+        self.awq_model.model.model.rotary_emb.to("cpu")
 
         clear_memory()
 

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -542,7 +542,6 @@ class AwqQuantizer:
         best_device = get_best_device()
         modules[0] = modules[0].to(best_device)
         self.awq_model.move_embed(self.model, best_device)
-        self.awq_model.model.model.rotary_emb.to(best_device)
 
         # get input and kwargs to layer 0
         # with_kwargs is only supported in PyTorch 2.0
@@ -584,7 +583,6 @@ class AwqQuantizer:
 
         modules[0] = modules[0].cpu()
         self.awq_model.move_embed(self.model, "cpu")
-        self.awq_model.model.model.rotary_emb.to("cpu")
 
         clear_memory()
 


### PR DESCRIPTION
This PR moves the rotary embeddings to the appropriate device to avoid having tensors on multiple devices; adds compatibility with transformers versions 4.43.0 and newer. Developed thanks to the help of @SunMarc (see history in this closed transformers PR: https://github.com/huggingface/transformers/pull/33742).

This fixes several issues here for AutoAWQ: #510, #558, #571, #585

Another relevant issue that this would close over in transformers is here: https://github.com/huggingface/transformers/issues/32420