### PR TITLE
Only build once

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,8 +39,8 @@ jobs:
     
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest]
-        pyver: ["3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-20.04]
+        pyver: ["3.9"]
     defaults:
       run:
         shell: pwsh


### PR DESCRIPTION
We only need to build once since AutoAWQ is not OS independent and does not rely on CUDA extensions.