### PR TITLE
Post release 2 - All additional packages goes into extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,15 @@ There are a few ways to install AutoAWQ:
 1. Default:
     - `pip install autoawq`
     - NOTE: The default installation includes no external kernels and relies on Triton for inference.
-    
-2. From main branch with kernels:
-    - `INSTALL_KERNELS=1 pip install git+https://github.com/casper-hansen/AutoAWQ.git`
+
+2. From release with kernels:
+    - `pip install autoawq[kernels]`
+    - NOTE: This requires you to match the latest torch version that the kernels were build with.
     - NOTE: This installs https://github.com/casper-hansen/AutoAWQ_kernels
 
 3. From main branch for Intel CPU and Intel XPU optimized performance:
-    - `pip install intel_extension_for_pytorch`
-    - `pip install git+https://github.com/casper-hansen/AutoAWQ.git`
+    - `pip install autoawq[cpu]`
+    - NOTE: Minimum of torch 2.4.0 is required.
 
 ## Usage
 

--- a/awq/__init__.py
+++ b/awq/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.2.7.post1"
+__version__ = "0.2.7.post2"
 from awq.models.auto import AutoAWQForCausalLM

--- a/scripts/download_wheels.sh
+++ b/scripts/download_wheels.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set variables
-AWQ_VERSION="0.2.7.post1"
+AWQ_VERSION="0.2.7.post2"
 RELEASE_URL="https://api.github.com/repos/casper-hansen/AutoAWQ/releases/tags/v${AWQ_VERSION}"
 
 # Create a directory to download the wheels

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,8 @@ import torch
 from pathlib import Path
 from setuptools import setup, find_packages
 
-AUTOAWQ_VERSION = "0.2.7.post1"
-INSTALL_KERNELS = os.getenv("INSTALL_KERNELS", "0") == "1"
-IS_CPU_ONLY = not torch.backends.mps.is_available() and not torch.cuda.is_available()
+AUTOAWQ_VERSION = "0.2.7.post2"
 TORCH_VERSION = str(os.getenv("TORCH_VERSION", None) or torch.__version__).split('+', maxsplit=1)[0]
-
-CUDA_VERSION = os.getenv("CUDA_VERSION", None) or torch.version.cuda
-if CUDA_VERSION:
-    CUDA_VERSION = "".join(CUDA_VERSION.split("."))[:3]
 
 common_setup_kwargs = {
     "version": AUTOAWQ_VERSION,
@@ -50,25 +44,14 @@ requirements = [
     "zstandard",
 ]
 
-try:
-    import awq_ext
-
-    KERNELS_INSTALLED = True
-except ImportError:
-    KERNELS_INSTALLED = False
-
-if not KERNELS_INSTALLED and CUDA_VERSION and INSTALL_KERNELS and CUDA_VERSION.startswith("12"):
-    requirements.append("autoawq-kernels")
-
-elif IS_CPU_ONLY:
-    requirements.append("intel-extension-for-pytorch>=2.4.0")
-
 setup(
     packages=find_packages(),
     install_requires=requirements,
     extras_require={
         "eval": ["lm_eval==0.4.1", "tabulate", "protobuf", "evaluate", "scipy"],
         "dev": ["black", "mkdocstrings-python", "mkdocs-material", "griffe-typingdoc"],
+        "cpu": ["intel-extension-for-pytorch>=2.4.0"],
+        "kernels": ["autoawq-kernels"],
     },
     **common_setup_kwargs,
 )


### PR DESCRIPTION
- `pip install autoawq[cpu]` to install with IPEX support
- `pip install autoawq[kernels]` to install autoawq-kernels
- bump to `0.2.7.post2`