### PR TITLE
Fused attention: Switch to Flash Decoding

### DIFF
--- a/awq/modules/fused/attn.py
+++ b/awq/modules/fused/attn.py
@@ -8,11 +8,11 @@ from awq.utils.fused_utils import get_attention_shapes
 
 
 try:
-    import awq_ft_ext
+    from flash_attn import flash_attn_func, flash_attn_with_kvcache
 
-    FT_INSTALLED = True
+    FA_INSTALLED = True
 except:
-    FT_INSTALLED = False
+    FA_INSTALLED = False
 
 HF_NEW_CACHE_FORMAT = False
 
@@ -28,6 +28,7 @@ class RoPE(nn.Module):
     def __init__(self, head_dim, max_seq_len, device, rope_theta):
         super(RoPE, self).__init__()
 
+        self.head_dim = head_dim
         self.freqs_cis = nn.Parameter(
             self.precompute_freqs_cis(head_dim, max_seq_len, rope_theta).to(device),
             requires_grad=False,
@@ -49,7 +50,16 @@ class RoPE(nn.Module):
         shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
         return freqs_cis.view(*shape)
 
-    def forward(self, xq: torch.Tensor, xk: torch.Tensor, start_pos: int, seqlen: int):
+    def forward(self, xq: torch.Tensor, xk: torch.Tensor, start_pos: int, seqlen: int, partial: bool = False):
+        if partial:
+            xq, xq_pass = (
+                xq[..., : self.head_dim],
+                xq[..., self.head_dim :],
+            )
+            xk, xk_pass = (
+                xk[..., : self.head_dim],
+                xk[..., self.head_dim :],
+            )
         xq_ = torch.view_as_complex(
             xq.float().reshape(*xq.shape[:-1], 2, -1).transpose(-2, -1).contiguous()
         )
@@ -61,6 +71,10 @@ class RoPE(nn.Module):
 
         xq_out = torch.view_as_real(xq_ * freqs_cis).transpose(-2, -1).flatten(3)
         xk_out = torch.view_as_real(xk_ * freqs_cis).transpose(-2, -1).flatten(3)
+
+        if partial:
+            xq = torch.cat((xq, xq_pass), dim=-1)
+            xk = torch.cat((xk, xk_pass), dim=-1)
 
         return xq_out.type_as(xq), xk_out.type_as(xk)
 
@@ -118,7 +132,7 @@ class QuantAttentionFused(nn.Module):
         rope_theta=10000,
         partial_rotary_factor=1.0,
         head_dim=None,
-        attn_logit_softcapping=None,
+        attn_logit_softcapping=0.0,
         **kwargs
     ):
         super().__init__()
@@ -147,18 +161,18 @@ class QuantAttentionFused(nn.Module):
         # attention shapes for self attention
         self.attention_shapes = get_attention_shapes(
             attention_shapes,
-            max_seq_len,
-            self.cache_batch_size,
             n_heads,
             n_kv_heads,
             self.head_dim,
         )
         # cache store that rolls cache
         self.cache = WindowedCache(
-            self.attention_shapes["cache_v"],
-            self.attention_shapes["cache_k"],
-            self.max_seq_len,
-            dev,
+            cache_batch_size=self.cache_batch_size,
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=self.head_dim,
+            max_seq_len=self.max_seq_len,
+            device=dev,
         )
 
         if use_alibi:
@@ -176,7 +190,6 @@ class QuantAttentionFused(nn.Module):
             self.is_neox = kwargs["is_neox"]
         
         self.attn_logit_softcapping = attn_logit_softcapping
-        self.use_sdpa = kwargs.get("use_sdpa", False)
 
     def forward(
         self, hidden_states: torch.Tensor, attention_mask=None, *args, **kwargs
@@ -202,15 +215,12 @@ class QuantAttentionFused(nn.Module):
         if self.is_hf_transformers and "use_cache" in kwargs:
             hf_is_generating = kwargs["use_cache"]
 
-        # print(kwargs["past_key_value"].get_seq_length())
-
         # In case we re-generate, we need to refresh the starting position
         # to 0. We detect it by checking if `past_key_values` is set to None,
         # which indicates that we are on the first step of `generate()`.
         # This is only applicable for `transformers` integration
         if (self.is_hf_transformers and (hf_is_first_forward or hf_is_new_cache_first_forward)) or (self.is_hf_transformers and not hf_is_generating):
             self.start_pos = 0
-    
 
         xqkv = self.qkv_proj(hidden_states)
         xqkv = xqkv.view((bsz, seqlen) + self.attention_shapes["xqkv_view"])
@@ -219,113 +229,41 @@ class QuantAttentionFused(nn.Module):
         xk = self.attention_shapes["xk_slice"](xqkv)
         xv = self.attention_shapes["xv_slice"](xqkv)
 
-        if seqlen > 1 or self.partial_rotary_factor < 1 or not FT_INSTALLED:
-            xq = xq.view((bsz, seqlen) + self.attention_shapes["xq_view"])
-            xk = xk.view((bsz, seqlen) + self.attention_shapes["xk_view"])
-            xv = xv.view((bsz, seqlen) + self.attention_shapes["xv_view"])
+        if not self.use_alibi:
+            xq, xk = self.rope.forward(xq, xk, self.start_pos, seqlen, partial=self.partial_rotary_factor < 1)
 
-            if not self.use_alibi:
-                # Partial rotary embedding
-                if self.partial_rotary_factor < 1:
-                    xq_rot, xq_pass = (
-                        xq[..., : self.rotary_dim],
-                        xq[..., self.rotary_dim :],
-                    )
-                    xk_rot, xk_pass = (
-                        xk[..., : self.rotary_dim],
-                        xk[..., self.rotary_dim :],
-                    )
-                    xq_rot, xk_rot = self.rope.forward(xq_rot, xk_rot, self.start_pos, seqlen)
-                    xq = torch.cat((xq_rot, xq_pass), dim=-1)
-                    xk = torch.cat((xk_rot, xk_pass), dim=-1)
-                else:
-                    xq, xk = self.rope.forward(xq, xk, self.start_pos, seqlen)
-
-            values_store = xv.transpose(2, 1)
-            keys_store = (
-                xk.reshape((bsz, seqlen) + self.attention_shapes["xk_reshape"])
-                .permute(0, 2, 3, 1, 4)
-                .contiguous()
-            )
-
+        if seqlen > 1:
             self.cache.to(xq)
-            self.cache.update_kv(values_store, keys_store, bsz, self.start_pos, seqlen)
-
-            # Only necessary to retrieve from cache when we are not processing context
-            if seqlen == 1:
-                xv, xk = self.cache.get_kv(bsz, self.start_pos, seqlen, self.head_dim)
-
-            keys = xk
-            values = xv
-
-            if self.n_kv_groups != 0:
-                keys = torch.repeat_interleave(keys, dim=2, repeats=self.n_kv_groups)
-                values = torch.repeat_interleave(
-                    values, dim=2, repeats=self.n_kv_groups
-                )
-
-            xq = xq.transpose(1, 2)
-            keys = keys.transpose(1, 2)
-            values = values.transpose(1, 2)
-
-            # Used in Gemma2
-            if self.attn_logit_softcapping is not None:
-                scores = scores / self.attn_logit_softcapping
-                scores = torch.tanh(scores)
-                scores = scores * self.attn_logit_softcapping
-
-            if self.use_sdpa:
-                causal_mask = attention_mask
-                if attention_mask is not None:
-                    causal_mask = causal_mask[:, :, :, : keys.shape[-2]]
-                is_causal = True if causal_mask is None and seqlen > 1 else False
-                output = torch.nn.functional.scaled_dot_product_attention(
-                    xq,
-                    keys,
-                    values,
-                    attn_mask=causal_mask,
-                    dropout_p=0.0,
-                    is_causal=is_causal,
-                )
-            else:
-                scores = torch.matmul(xq, keys.transpose(2, 3)) / math.sqrt(self.head_dim)
-                if self.use_alibi:
-                    scores = self.alibi.forward(scores, seqlen)
-
-                # When seqlen is 1, there is nothing else to attend to
-                if attention_mask is not None and seqlen > 1:
-                    # For llama-arch, the causal mask is preallocated with bsz x 1 x max_seq_len x max_seq_len, thus we 
-                    # need to slice it
-                    if attention_mask.shape[-1] != seqlen:
-                        attention_mask = attention_mask[:, :, :seqlen, :seqlen]
-
-                    scores = (
-                        scores + attention_mask
-                    )  # (bs, n_local_heads, slen, cache_len + slen)
-                scores = F.softmax(scores.float(), dim=-1).type_as(xq)
-                output = torch.matmul(scores, values)  # (bs, n_local_heads, slen, head_dim)
+            self.cache.update_kv(
+                values_store=xv,
+                keys_store=xk,
+                batch_size=bsz,
+                start_pos=self.start_pos,
+                seqlen=seqlen,
+            )
+            
+            output = flash_attn_func(
+                q=xq,
+                k=xk,
+                v=xv,
+                causal=True,
+                alibi_slopes=self.alibi.slopes if self.alibi is not None else None,
+                softcap=self.attn_logit_softcapping,
+            )
 
             attention_weight = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
         else:
-            xq = xq.view((bsz,) + self.attention_shapes["single_xq_view"])
-            xk = xk.view((bsz,) + self.attention_shapes["single_xk_view"])
-            xv = xv.view((bsz,) + self.attention_shapes["single_xv_view"])
+            xv, xk = self.cache.get_kv(bsz, self.start_pos, seqlen, self.head_dim)
 
-            alibi_slopes = self.alibi.slopes if self.alibi is not None else None
-            attention_weight = awq_ft_ext.single_query_attention(
-                xq,  # query
-                xk,  # key
-                xv,  # value
-                self.cache.k,  # key cache
-                self.cache.v,  # value cache
-                None,  # length per sample
-                alibi_slopes,  # alibi slopes
-                self.start_pos,  # timestep
-                self.rotary_dim,  # rotary embedding dimension
-                self.rope_theta,  # rotary embedding base
-                self.is_neox,  # is neox
+            output = flash_attn_func(
+                q=xq,
+                k=xk,
+                v=xv,
+                causal=True,
+                alibi_slopes=self.alibi.slopes if self.alibi is not None else None,
+                softcap=self.attn_logit_softcapping,
             )
-            attention_weight = attention_weight.reshape(bsz, 1, -1)
+            attention_weight = output.reshape(bsz, seqlen, -1)
 
         attn_output = self.o_proj(attention_weight)
         self.start_pos += seqlen
@@ -337,7 +275,6 @@ class QuantAttentionFused(nn.Module):
         # we pass a dummy past kv cache for transformers to be able to retrieve the correct info
         # about past key length
         past_key_value = [torch.zeros(1, 1, self.start_pos, 1)]
-
 
         if HF_NEW_CACHE_FORMAT and self.is_hf_transformers:
             new_cache = DynamicCache()

--- a/awq/modules/fused/block.py
+++ b/awq/modules/fused/block.py
@@ -106,7 +106,6 @@ class LlamaLikeBlock(nn.Module):
             rope_theta=rope_theta,
             partial_rotary_factor=partial_rotary_factor,
             head_dim=head_dim,
-            use_sdpa=True,
         ).to(dev)
         self.norm_2 = norm_2.to(dev)
         self.mlp = mlp.to(dev)

--- a/awq/modules/fused/block.py
+++ b/awq/modules/fused/block.py
@@ -41,23 +41,17 @@ class MixtralBlock(nn.Module):
     def forward(
         self,
         hidden_states,
-        past_key_value,
-        attn_bias=None,
-        attention_mask=None,
-        is_causal=None,
     ):
         norm_out = self.norm_1(hidden_states)
-        attn_output, _, past_key_value = self.attn.forward(
+        attn_output, _, _ = self.attn.forward(
             hidden_states=norm_out,
-            past_key_value=past_key_value,
-            attention_mask=attention_mask,
         )
 
         h = hidden_states.to(attn_output.device) + attn_output
         out = self.moe.forward(self.norm_2(h))
         out = h + out
 
-        return out, None, past_key_value
+        return out
 
 
 class LlamaLikeBlock(nn.Module):
@@ -114,22 +108,16 @@ class LlamaLikeBlock(nn.Module):
     def forward(
         self,
         hidden_states,
-        past_key_value,
-        attn_bias=None,
-        attention_mask=None,
-        is_causal=None,
     ):
         norm_out = self.norm_1(hidden_states)
-        attn_output, _, past_key_value = self.attn.forward(
+        attn_output, _, _ = self.attn.forward(
             hidden_states=norm_out,
-            past_key_value=past_key_value,
-            attention_mask=attention_mask,
         )
 
         h = hidden_states.to(attn_output.device) + attn_output
         out = h + self.mlp.forward(self.norm_2(h))
 
-        return out, None, past_key_value
+        return out
 
 
 class Gemma2LikeBlock(nn.Module):
@@ -143,8 +131,8 @@ class Gemma2LikeBlock(nn.Module):
         mlp,
         norm_1,
         norm_2,
-    	norm_3,
-    	norm_4,
+        norm_3,
+        norm_4,
         dev,
         max_seq_len,
         rope_theta=10000,
@@ -187,30 +175,24 @@ class Gemma2LikeBlock(nn.Module):
     def forward(
         self,
         hidden_states,
-        past_key_value,
-        attn_bias=None,
-        attention_mask=None,
-        is_causal=None,
     ):
         residual = hidden_states
         hidden_states = self.norm_1(hidden_states)
 
-        hidden_states, _, past_key_value = self.attn.forward(
+        hidden_states, _, _ = self.attn.forward(
             hidden_states=hidden_states,
-            past_key_value=past_key_value,
-            attention_mask=attention_mask,
         )
 
         hidden_states = self.norm_2(hidden_states)
         hidden_states = residual + hidden_states
-        
+
         residual = hidden_states
         hidden_states = self.norm_3(hidden_states)
         hidden_states = self.mlp(hidden_states)
         hidden_states = self.norm_4(hidden_states)
         out = residual + hidden_states
 
-        return out, None, past_key_value
+        return out
 
 
 class CohereBlock(nn.Module):
@@ -223,7 +205,6 @@ class CohereBlock(nn.Module):
         o_proj,
         mlp,
         norm_1,
-        # norm_2,
         dev,
         max_seq_len,
         rope_theta=10000,
@@ -255,29 +236,22 @@ class CohereBlock(nn.Module):
             head_dim=head_dim,
             is_neox=False,
         ).to(dev)
-        # self.norm_2 = norm_2.to(dev)
         self.mlp = mlp.to(dev)
         self.device = dev
 
     def forward(
         self,
         hidden_states,
-        past_key_value,
-        attn_bias=None,
-        attention_mask=None,
-        is_causal=None,
     ):
         norm_out = self.norm_1(hidden_states)
-        attn_output, _, past_key_value = self.attn.forward(
+        attn_output, _, _ = self.attn.forward(
             hidden_states=norm_out,
-            past_key_value=past_key_value,
-            attention_mask=attention_mask,
         )
 
         h = hidden_states.to(attn_output.device) + attn_output
         out = h + self.mlp.forward(norm_out)
 
-        return out, None, past_key_value
+        return out
 
 
 class MPTBlock(nn.Module):
@@ -315,24 +289,15 @@ class MPTBlock(nn.Module):
     def forward(
         self,
         hidden_states,
-        past_key_value,
-        attn_bias=None,
-        attention_mask=None,
-        is_causal=None,
     ):
         norm_out = self.norm_1(hidden_states)
-        attn_output, _, past_key_value = self.attn.forward(
+        attn_output, _, _ = self.attn.forward(
             hidden_states=norm_out,
-            past_key_value=past_key_value,
-            attention_mask=attention_mask,
-            position_ids=None,
-            output_attentions=False,
-            use_cache=True,
         )
 
         h = hidden_states.to(attn_output.device) + attn_output
         out = h + self.ffn.forward(self.norm_2(h))
-        return out, None, past_key_value
+        return out
 
 
 class FalconDecoderLayer(nn.Module):
@@ -422,10 +387,6 @@ class FalconDecoderLayer(nn.Module):
     def forward(
         self,
         hidden_states,
-        past_key_value,
-        attn_bias=None,
-        attention_mask=None,
-        is_causal=None,
     ):
         if self.new_decoder_arch:
             layernorm_out = self.ln_attn(hidden_states)
@@ -433,13 +394,8 @@ class FalconDecoderLayer(nn.Module):
         else:
             layernorm_out = self.input_layernorm(hidden_states)
 
-        attn_output, _, past_key_value = self.attn.forward(
+        attn_output, _, _ = self.attn.forward(
             hidden_states=layernorm_out,
-            past_key_value=past_key_value,
-            attention_mask=attention_mask,
-            position_ids=None,
-            output_attentions=False,
-            use_cache=True,
         )
 
         h_attn = hidden_states.to(attn_output.device) + attn_output
@@ -451,7 +407,7 @@ class FalconDecoderLayer(nn.Module):
 
         out = h_attn + h_mlp
 
-        return out, None, past_key_value
+        return out
 
 
 class Phi3Block(nn.Module):
@@ -508,19 +464,13 @@ class Phi3Block(nn.Module):
     def forward(
         self,
         hidden_states,
-        past_key_value,
-        attn_bias=None,
-        attention_mask=None,
-        is_causal=None,
     ):
         norm_out = self.norm_1(hidden_states)
-        attn_output, _, past_key_value = self.attn.forward(
+        attn_output, _, _ = self.attn.forward(
             hidden_states=norm_out,
-            past_key_value=past_key_value,
-            attention_mask=attention_mask,
         )
 
         h = hidden_states.to(attn_output.device) + attn_output
         out = h + self.mlp.forward(self.norm_2(h))
 
-        return out, None, past_key_value
+        return out

--- a/awq/modules/fused/cache.py
+++ b/awq/modules/fused/cache.py
@@ -25,19 +25,12 @@ class WindowedCache:
         )
         self.max_seq_len = max_seq_len
 
-    def get_kv(self, batch_size, start_pos, seqlen, head_dim):
+    def get_kv(self, batch_size, start_pos, seqlen):
         """
         Gets the key-value store in correct shapes.
         """
-        xv = (
-            self.v[:batch_size, start_pos + seqlen].transpose(1, 2).contiguous()
-        )
-        xk = (
-            self.k[:batch_size, start_pos + seqlen]
-            .transpose(2, 3)
-            .contiguous()
-        )
-        xk = xk.reshape(xk.shape[:-2] + (head_dim,)).transpose(1, 2).contiguous()
+        xv = self.v[:batch_size, :start_pos + seqlen]
+        xk = self.k[:batch_size, :start_pos + seqlen]
 
         return xv, xk
 

--- a/awq/modules/fused/cache.py
+++ b/awq/modules/fused/cache.py
@@ -2,7 +2,9 @@ import torch
 
 
 class WindowedCache:
-    def __init__(self, cache_batch_size, n_heads, n_kv_heads, head_dim, max_seq_len, device):
+    def __init__(
+        self, cache_batch_size, n_heads, n_kv_heads, head_dim, max_seq_len, device
+    ):
         """
         The window size is the same as the max_seq_len. The window will
         automatically roll once max_seq_len is exceeded.
@@ -31,8 +33,8 @@ class WindowedCache:
         NOTE: This function is a legacy function. It is only available to showcase
               how to accurately retrieve the KV-cache but is not currently used.
         """
-        xv = self.v[:batch_size, :start_pos + seqlen]
-        xk = self.k[:batch_size, :start_pos + seqlen]
+        xv = self.v[:batch_size, : start_pos + seqlen]
+        xk = self.k[:batch_size, : start_pos + seqlen]
 
         return xv, xk
 

--- a/awq/modules/fused/cache.py
+++ b/awq/modules/fused/cache.py
@@ -2,15 +2,27 @@ import torch
 
 
 class WindowedCache:
-    def __init__(self, cache_v_shape, cache_k_shape, max_seq_len, device):
+    def __init__(self, cache_batch_size, n_heads, n_kv_heads, head_dim, max_seq_len, device):
         """
         The window size is the same as the max_seq_len. The window will
         automatically roll once max_seq_len is exceeded.
         """
-        # [batch_size, n_kv_heads, max_seq_len, head_dim]
-        self.v = torch.zeros(cache_v_shape).to(device).half()
-        # [batch_size, n_kv_heads, head_dim // pack_factor, max_seq_len, pack_factor]
-        self.k = torch.zeros(cache_k_shape).to(device).half()
+        size = (
+            cache_batch_size,
+            max_seq_len,
+            n_kv_heads if n_kv_heads != 0 else n_heads,
+            head_dim,
+        )
+        self.v = torch.zeros(
+            size,
+            device=device,
+            dtype=torch.float16,
+        )
+        self.k = torch.zeros(
+            size,
+            device=device,
+            dtype=torch.float16,
+        )
         self.max_seq_len = max_seq_len
 
     def get_kv(self, batch_size, start_pos, seqlen, head_dim):
@@ -18,10 +30,10 @@ class WindowedCache:
         Gets the key-value store in correct shapes.
         """
         xv = (
-            self.v[:batch_size, :, : start_pos + seqlen, :].transpose(1, 2).contiguous()
+            self.v[:batch_size, start_pos + seqlen].transpose(1, 2).contiguous()
         )
         xk = (
-            self.k[:batch_size, :, :, : start_pos + seqlen, :]
+            self.k[:batch_size, start_pos + seqlen]
             .transpose(2, 3)
             .contiguous()
         )
@@ -33,8 +45,8 @@ class WindowedCache:
         """
         Updates the values in the key-value store.
         """
-        self.v[:batch_size, :, start_pos : start_pos + seqlen, :] = values_store
-        self.k[:batch_size, :, :, start_pos : start_pos + seqlen, :] = keys_store
+        self.v[:batch_size, start_pos : start_pos + seqlen, :, :] = values_store
+        self.k[:batch_size, start_pos : start_pos + seqlen, :, :] = keys_store
 
     def roll_kv_n_steps(self, start_pos, n=100):
         """

--- a/awq/modules/fused/cache.py
+++ b/awq/modules/fused/cache.py
@@ -28,6 +28,8 @@ class WindowedCache:
     def get_kv(self, batch_size, start_pos, seqlen):
         """
         Gets the key-value store in correct shapes.
+        NOTE: This function is a legacy function. It is only available to showcase
+              how to accurately retrieve the KV-cache but is not currently used.
         """
         xv = self.v[:batch_size, :start_pos + seqlen]
         xk = self.k[:batch_size, :start_pos + seqlen]

--- a/awq/modules/fused/moe.py
+++ b/awq/modules/fused/moe.py
@@ -91,7 +91,6 @@ def apply_moe_weights(
     return torch.sum(out, dim=1)
 
 
-
 def moe_align_block_size(topk_ids: torch.Tensor, block_size: int, num_experts: int):
     """
     Aligns the token distribution across experts to be compatible with block size for matrix multiplication.

--- a/awq/modules/fused/norm.py
+++ b/awq/modules/fused/norm.py
@@ -31,6 +31,8 @@ class FasterTransformerRMSNorm(nn.Module):
                 "Please install them from https://github.com/casper-hansen/AutoAWQ_kernels"
             )
             output = torch.empty_like(x)
-            awq_ext.layernorm_forward_cuda(x, self.weight, output, self.variance_epsilon)
+            awq_ext.layernorm_forward_cuda(
+                x, self.weight, output, self.variance_epsilon
+            )
 
         return output

--- a/awq/utils/fused_utils.py
+++ b/awq/utils/fused_utils.py
@@ -11,15 +11,6 @@ from awq.modules.linear import (
 )
 
 
-def prepare_correct_devices(next_layer, hidden_states, mask):
-    hidden_states = hidden_states.to(next_layer.device)
-
-    if mask is not None:
-        mask = mask.to(next_layer.device)
-
-    return hidden_states, mask
-
-
 def prepare_cache(blocks, seqlen: int) -> int:
     for block in blocks:
         start_pos = block.attn.start_pos
@@ -49,15 +40,6 @@ def prepare_input_ids(input_ids: torch.Tensor, last_forward_num_tokens: int):
             input_ids = input_ids[:, -1:]
 
     return input_ids, last_forward_num_tokens + num_new_tokens
-
-
-def prepare_attention_mask(seqlen, start_pos, device, type_as: torch.Tensor):
-    mask = None
-    if seqlen > 1:
-        mask = torch.full((1, 1, seqlen, seqlen), float("-inf"), device=device)
-        mask = torch.triu(mask, diagonal=start_pos + 1).type_as(type_as)
-
-    return mask
 
 
 def fuse_qkv(module, q_proj, k_proj, v_proj):

--- a/awq/utils/fused_utils.py
+++ b/awq/utils/fused_utils.py
@@ -181,28 +181,13 @@ def fuse_linears(linears, device, dim=1, operation=torch.cat):
 
 
 def get_attention_shapes(
-    attention_shapes, max_seq_len, cache_batch_size, n_heads, n_kv_heads, head_dim
+    attention_shapes, n_heads, n_kv_heads, head_dim
 ):
     if attention_shapes is not None:
         attention_shapes = attention_shapes
 
     elif n_kv_heads == 0:
         attention_shapes = {
-            # following fastertransformer definition
-            "cache_v": (
-                cache_batch_size,
-                n_heads,
-                max_seq_len,
-                head_dim,
-            ),
-            # 8: pack 8 fp16 in FT, if fp32 then use 4
-            "cache_k": (
-                cache_batch_size,
-                n_heads,
-                head_dim // 8,
-                max_seq_len,
-                8,
-            ),
             "xqkv_view": (-1, n_heads, head_dim),
             "xq_slice": lambda xqkv: xqkv[:, :, 0],
             "xk_slice": lambda xqkv: xqkv[:, :, 1],
@@ -218,21 +203,6 @@ def get_attention_shapes(
 
     else:
         attention_shapes = {
-            # following fastertransformer definition
-            "cache_v": (
-                cache_batch_size,
-                n_kv_heads,
-                max_seq_len,
-                head_dim,
-            ),
-            # 8: pack 8 fp16 in FT, if fp32 then use 4
-            "cache_k": (
-                cache_batch_size,
-                n_kv_heads,
-                head_dim // 8,
-                max_seq_len,
-                8,
-            ),
             "xqkv_view": (n_heads + n_kv_heads * 2, head_dim),
             "xq_slice": lambda xqkv: xqkv[:, :, 0:n_heads],
             "xk_slice": lambda xqkv: xqkv[:, :, n_heads : (n_heads + n_kv_heads)],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "eval": ["lm_eval==0.4.1", "tabulate", "protobuf", "evaluate", "scipy"],
         "dev": ["black", "mkdocstrings-python", "mkdocs-material", "griffe-typingdoc"],
         "cpu": ["intel-extension-for-pytorch>=2.4.0"],
-        "kernels": ["autoawq-kernels"],
+        "kernels": ["autoawq-kernels", "flash-attn>=2.2.0"],
     },
     **common_setup_kwargs,
 )


### PR DESCRIPTION
## Current implementation

```
Device: cuda:0
GPU: NVIDIA GeForce RTX 4090
Model: hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4
Version: gemm
|   Batch Size |   Prefill Length |   Decode Length |   Prefill tokens/s |   Decode tokens/s | Memory (VRAM)    |
|-------------:|-----------------:|----------------:|-------------------:|------------------:|:-----------------|
|            1 |               32 |              32 |             213.47 |             97.07 | 5.48 GB (23.16%) |
|            1 |               64 |              64 |            3985.32 |             96.23 | 5.48 GB (23.20%) |
|            1 |              128 |             128 |            4977.39 |             94.95 | 5.50 GB (23.27%) |
|            1 |              256 |             256 |            5416.4  |             94.45 | 5.54 GB (23.42%) |
|            1 |              512 |             512 |            5403.73 |             93.73 | 5.64 GB (23.87%) |
|            1 |             1024 |            1024 |            7218.92 |             92.74 | 5.89 GB (24.90%) |
|            1 |             2048 |            2048 |            7684.16 |             83.76 | 6.43 GB (27.21%) |
|            1 |             4096 |            4096 |            7308.05 |             59.79 | 7.52 GB (31.82%) |
```

## With `flash-attn`

```
Device: cuda:0
GPU: NVIDIA GeForce RTX 4090
Model: hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4
Version: gemm
|   Batch Size |   Prefill Length |   Decode Length |   Prefill tokens/s |   Decode tokens/s | Memory (VRAM)    |
|-------------:|-----------------:|----------------:|-------------------:|------------------:|:-----------------|
|            1 |               32 |              32 |             232.19 |            107.17 | 5.48 GB (23.16%) |
|            1 |               64 |              64 |            4030.56 |            106.3  | 5.48 GB (23.20%) |
|            1 |              128 |             128 |            5044.31 |            104.98 | 5.50 GB (23.27%) |
|            1 |              256 |             256 |            5290.12 |            104.99 | 5.54 GB (23.42%) |
|            1 |              512 |             512 |            5457.14 |            104.55 | 5.64 GB (23.87%) |
|            1 |             1024 |            1024 |            7465.82 |            104.06 | 5.88 GB (24.85%) |
|            1 |             2048 |            2048 |            8284.3  |            104.03 | 6.41 GB (27.12%) |
|            1 |             4096 |            4096 |            8487.37 |            103.77 | 7.48 GB (31.63%) |
```