### PR TITLE
Support building on the RISC-V platform.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import torch
+import platform
 from pathlib import Path
 from setuptools import setup, find_packages
 
@@ -44,6 +45,10 @@ requirements = [
     "zstandard",
     "huggingface_hub>=0.26.5",
 ]
+
+if 'riscv' in platform.machine().lower():
+    # remove triton for riscv platform
+    requirements.remove("triton")
 
 setup(
     packages=find_packages(),


### PR DESCRIPTION
When building on the RISC-V platform, remove the dependency on Triton.

@casper-hansen hi~ casper, AutoAWQ is a great project, and we currently hope to use AutoAWQ on the RISC-V platform. However, when compiling the WHL, it seems to depend on the Triton project. I submitted this PR with the aim of removing the Triton dependency when building the WHL for the RV platform.

