### PR TITLE
add support for telechat2

### DIFF
--- a/awq/models/__init__.py
+++ b/awq/models/__init__.py
@@ -28,3 +28,4 @@ from .minicpm import MiniCPMAWQForCausalLM
 from .internlm2 import InternLM2AWQForCausalLM
 from .minicpm3 import MiniCPM3AWQForCausalLM
 from .qwen2vl import Qwen2VLAWQForCausalLM
+from .telechat2 import Telechat2AWQForCausalLM

--- a/awq/models/auto.py
+++ b/awq/models/auto.py
@@ -38,6 +38,7 @@ AWQ_CAUSAL_LM_MODEL_MAP = {
     "internlm2": InternLM2AWQForCausalLM,
     "minicpm3": MiniCPM3AWQForCausalLM,
     "qwen2_vl": Qwen2VLAWQForCausalLM,
+    "telechat": Telechat2AWQForCausalLM,
 }
 
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -86,6 +86,7 @@ TRANSFORMERS_AUTO_MAPPING_DICT = {
     "minicpm3":"AutoModelForCausalLM",
     "internlm2": "AutoModelForCausalLM",
     "qwen2_vl": "AutoModelForVision2Seq",
+    "telechat": "AutoModelForCausalLM",
 }
 
 

--- a/awq/models/telechat2.py
+++ b/awq/models/telechat2.py
@@ -1,0 +1,72 @@
+from typing import List, Tuple
+from .base import BaseAWQForCausalLM
+
+# VLLM now supports telechat2,
+# but the transformer library does not yet support it,
+# so the following type prompts will be improved later
+
+class OldTelechat2Block:
+    """
+    Just as a type description, consistent with the modeling_telechat.py
+    """
+    ...
+
+class OldTelechatForCausalLM:
+    """
+    Just as a type description, consistent with the modeling_telechat.py
+    """
+    ...
+
+class Telechat2AWQForCausalLM(BaseAWQForCausalLM):
+    layer_type = "TelechatBlock"
+    max_seq_len_key = "training_seqlen"
+    modules_to_not_convert = ['query', 'key_value', 'dense']
+
+    @staticmethod
+    def fuse_layers(model: OldTelechatForCausalLM):
+        raise NotImplementedError()
+
+    @staticmethod
+    def get_model_layers(model: OldTelechatForCausalLM):
+        return model.transformer.h
+
+    @staticmethod
+    def get_act_for_scaling(module: OldTelechat2Block):
+        return dict(is_scalable=False)
+
+    @staticmethod
+    def move_embed(model: OldTelechatForCausalLM, device: str):
+        model.transformer.word_embeddings = model.transformer.word_embeddings.to(device)
+
+    @staticmethod
+    def get_layers_for_scaling(module: OldTelechat2Block, input_feat, module_kwargs):
+        """
+        Due to the unique organization of key value weights in telechat2,
+        the qkv and dense layers cannot be quantified
+        """
+        layers = []
+
+        # linear 1
+        layers.append(
+            dict(
+                prev_op=module.post_attention_layernorm,
+                layers=[module.mlp.gate_proj, module.mlp.up_proj],
+                inp=input_feat["mlp.gate_proj"],
+                module2inspect=module.mlp,
+                kwargs={
+                    "residual": input_feat['post_attention_layernorm']
+                }
+            )
+        )
+
+        # linear 2
+        layers.append(
+            dict(
+                prev_op=module.mlp.up_proj,
+                layers=[module.mlp.down_proj],
+                inp=input_feat["mlp.down_proj"],
+            )
+        )
+
+        return layers
+


### PR DESCRIPTION
Two minor changes:
1. Add support for the Telechat model (VLLM now supports the Telechat model).
2. When executing the forward function, it is necessary to place the tensor in kwargs on a suitable device.