### PR TITLE
Enable triton on XPU devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ AutoAWQ is an easy-to-use package for 4-bit quantized models. AutoAWQ speeds up 
   -  Your ROCm version must be compatible with Triton.
 - Intel CPU and Intel GPU:
   - Your torch and intel_extension_for_pytorch package version should at least 2.4 for optimized performance.
+  - Alternatively, you can rely on triton kernels for GPU, then you'll need to install [intel-xpu-backend-for-triton](https://github.com/intel/intel-xpu-backend-for-triton) along with compatible torch and transformers. Easiest way is to use [pre-built wheels](https://github.com/intel/intel-xpu-backend-for-triton?tab=readme-ov-file#install-pytorch-and-triton-from-nightly-wheels).
 
 ### Install from PyPi
 

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -29,7 +29,7 @@ from awq.utils.module import (
     exclude_layers_to_not_quantize,
     try_import,
 )
-from awq.utils.utils import get_best_device, ipex_available
+from awq.utils.utils import get_best_device, ipex_available, triton_available
 from transformers import (
     AutoConfig,
     PreTrainedModel,
@@ -498,7 +498,8 @@ class BaseAWQForCausalLM(nn.Module):
             )
 
         best_device = get_best_device()
-        use_ipex = use_ipex or best_device in ["cpu", "xpu:0"]
+        if best_device == "cpu" or (best_device == "xpu:0" and not triton_available):
+            use_ipex = True
         if use_ipex and not ipex_available:
             raise ImportError(
                 "Please install intel_extension_for_pytorch with "

--- a/awq/modules/linear/gemm.py
+++ b/awq/modules/linear/gemm.py
@@ -14,9 +14,8 @@ user_has_been_warned = False
 try:
     from awq.modules.triton.gemm import awq_gemm_triton, awq_dequantize_triton
 
-    # covers both CUDA and ROCm
-    if torch.cuda.is_available():
-        TRITON_AVAILABLE = True
+    # covers CUDA, ROCm and XPU. If we can import triton, then we can use it.
+    TRITON_AVAILABLE = True
 
 except ImportError:
     TRITON_AVAILABLE = False

--- a/awq/modules/triton/gemm.py
+++ b/awq/modules/triton/gemm.py
@@ -4,7 +4,7 @@
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# You may obtain a copy of the License at 
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #

--- a/awq/utils/utils.py
+++ b/awq/utils/utils.py
@@ -5,6 +5,12 @@ import accelerate
 
 
 ipex_available = importlib.util.find_spec("intel_extension_for_pytorch") is not None
+try:
+    import triton as tl
+    triton_available = True
+except ImportError:
+    triton_available = False
+
 
 
 def get_module_by_name_suffix(model, module_name: str):


### PR DESCRIPTION
Enable triton on XPU devices.

There is a working triton on XPU from Intel here: https://github.com/intel/intel-xpu-backend-for-triton/tree/llvm-target

I tested on laptop with Lunar Lake (integrated GPU) and it works with this [example](https://github.com/casper-hansen/AutoAWQ/blob/main/examples/generate.py), but I needed to disable layer fusing and manually put model to XPU:
```
model = AutoAWQForCausalLM.from_quantized(
  model_id,
  torch_dtype=torch.float16,
  low_cpu_mem_usage=True,
  device_map="auto",
  fuse_layers=False,
)
model.to('xpu')
```
I got about 3 t/s after I enabled cache.