### PR TITLE
Fixed issue with the slow implementation warning

### DIFF
--- a/awq/modules/linear/gemm.py
+++ b/awq/modules/linear/gemm.py
@@ -67,6 +67,7 @@ class WQLinearMMFunction(Function):
                 )
 
         else:
+            global user_has_been_warned
             if not user_has_been_warned:
                 warnings.warn("Using naive (slow) implementation." + msg)
                 user_has_been_warned = True


### PR DESCRIPTION
Currently there is a bug if we go into the last else:
```
  File "/storage/ekrivov/AutoAWQ/awq/modules/linear/gemm.py", line 270, in forward
    out = WQLinearMMFunction.apply(
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniforge3/envs/triton/lib/python3.12/site-packages/torch/autograd/function.py", line 578, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/storage/ekrivov/AutoAWQ/awq/modules/linear/gemm.py", line 70, in forward
    if not user_has_been_warned:
           ^^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'user_has_been_warned' where it is not associated with a value
```
The issue is that we modify this variable 2 lines below, so python assumes it's a local variable and now we are trying to access unbound local variable.
```
            if not user_has_been_warned:
                warnings.warn("Using naive (slow) implementation." + msg)
                user_has_been_warned = True
```

We need to make it global before we can modify it. And we have to make it global before the first read access.
