### PR TITLE
fix dtype mismatch

### DIFF
--- a/awq/modules/linear/gemm.py
+++ b/awq/modules/linear/gemm.py
@@ -60,7 +60,7 @@ class WQLinearMMFunction(Function):
 
             if FP16_MATMUL_HEURISTIC_CONDITION:
                 out = awq_dequantize_triton(qweight, scales, qzeros)
-                out = torch.matmul(x, out)
+                out = torch.matmul(x, out.to(x.dtype))
             else:
                 out = awq_gemm_triton(
                     x.reshape(-1, x.shape[-1]), qweight, scales, qzeros, split_k_iters=8,


### PR DESCRIPTION
Hi @casper-hansen . Some models are original BF16 like llama3-8B, but the triton gemm path dequantize weight to float16 which will mismatch the data dtype. Please review this change. Thanks!