### PR TITLE
Add Jupyter Notebook support for rich tqdm progress bar display

### DIFF
--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -5,7 +5,7 @@ import torch
 import transformers
 import torch.nn as nn
 
-from tqdm import tqdm
+from tqdm import auto as tqdm_lib
 from typing import List, Union, Dict
 from typing_extensions import Doc, Annotated
 from huggingface_hub import snapshot_download, save_torch_state_dict
@@ -640,7 +640,7 @@ class BaseAWQForCausalLM(nn.Module):
         # Get blocks of model
         layers = self.get_model_layers(model)
 
-        for i in tqdm(range(len(layers)), desc="Replacing layers..."):
+        for i in tqdm_lib.tqdm(range(len(layers)), desc="Replacing layers..."):
             layer = layers[i]
 
             # Get every linear layer in a block

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -4,7 +4,7 @@ import inspect
 import logging
 import functools
 import torch.nn as nn
-from tqdm import tqdm
+from tqdm import auto as tqdm_lib
 from typing import Dict, List, Optional
 from collections import defaultdict
 from awq.utils.calib_data import get_calib_dataset
@@ -125,7 +125,7 @@ class AwqQuantizer:
         return w
 
     def quantize(self):
-        for i in tqdm(range(len(self.modules)), desc="AWQ"):
+        for i in tqdm_lib.tqdm(range(len(self.modules)), desc="AWQ"):
             # Move module and inputs to correct device
             common_device = next(self.modules[i].parameters()).device
             if common_device is None or str(common_device) == "cpu":
@@ -212,7 +212,7 @@ class AwqQuantizer:
             clear_memory()
 
     def pack(self):
-        for i in tqdm(range(len(self.modules)), desc="Packing"):
+        for i in tqdm_lib.tqdm(range(len(self.modules)), desc="Packing"):
             named_linears = get_named_linears(self.modules[i])
             named_linears = exclude_layers_to_not_quantize(
                 named_linears, self.modules_to_not_convert


### PR DESCRIPTION
The tqdm progress bar in quantizer.py and base.py has been changed so that it can be used in both notebook and terminal.

**terminal**
![tqdm_terminal](https://github.com/user-attachments/assets/35ef9a43-0c1e-4ab0-a722-d23de439250e)

**notebook**
![tqdm_auto](https://github.com/user-attachments/assets/f6ee34ce-39db-4ddf-89a4-7f1ce773031a)


Thank you for considering this contribution!