### PR TITLE
fix: mrope cause shpae is not match

### DIFF
--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -275,6 +275,9 @@ class AwqQuantizer:
             # but only n_parallel_calib_samples at a time
             module_output = []
             partitioned_inputs = torch.split(x, self.n_parallel_calib_samples)
+            if 'position_embeddings' in module_kwargs:
+                module_kwargs['position_embeddings'] = (module_kwargs['position_embeddings'][0][:, :self.n_parallel_calib_samples],
+                                                         module_kwargs['position_embeddings'][1][:, :self.n_parallel_calib_samples])
             for x_partial in partitioned_inputs:
                 partial_output = module(x_partial, **module_kwargs)
 


### PR DESCRIPTION
问题复现方式：
在量化qwen2.5 vl模型时，设置n_parallel_calib_samples参数，会导致transformers在计算rope是，出现shape不匹配的问题

原因是qwen2.5 vl模型使用了mrope，也就是3维rope算法，它传入的position_embedding参数包含三种不同的频率，导致postion_embedding的shape出现变化，原始的方法不能兼容这种变化

备注：
这个样例只是做了简单实现，需要maintainer做更好的集成

​​Issue Reproduction Steps:​​
When quantizing the Qwen2.5-VL model, setting the n_parallel_calib_samples parameter causes a shape mismatch error in the transformers library during RoPE (Rotary Position Embedding) computation.

​​Root Cause:​​
The Qwen2.5-VL model uses ​​MRoPE (Multi-dimensional RoPE)​​, a 3D RoPE variant. This means the position_embedding parameter contains ​​three different frequency components​​, altering its shape. The original implementation does not account for this change, leading to compatibility issues.

​​Note:​​
This example provides a minimal fix. A more robust integration should be implemented by the maintainers.