### PR TITLE
Add Qwen2.5-Omni support.

### DIFF
--- a/awq/models/__init__.py
+++ b/awq/models/__init__.py
@@ -32,3 +32,4 @@ from .internlm2 import InternLM2AWQForCausalLM
 from .minicpm3 import MiniCPM3AWQForCausalLM
 from .qwen2vl import Qwen2VLAWQForCausalLM
 from .qwen2_5_vl import Qwen2_5_VLAWQForCausalLM
+from .qwen2_5_omni import Qwen2_5_OmniAWQForConditionalGeneration

--- a/awq/models/auto.py
+++ b/awq/models/auto.py
@@ -43,6 +43,7 @@ AWQ_CAUSAL_LM_MODEL_MAP = {
     "minicpm3": MiniCPM3AWQForCausalLM,
     "qwen2_vl": Qwen2VLAWQForCausalLM,
     "qwen2_5_vl": Qwen2_5_VLAWQForCausalLM,
+    "qwen2_5_omni": Qwen2_5_OmniAWQForConditionalGeneration
 }
 
 
@@ -79,7 +80,6 @@ class AutoAWQForCausalLM:
         model_type = check_and_get_model_type(
             model_path, trust_remote_code, **model_init_kwargs
         )
-
         return AWQ_CAUSAL_LM_MODEL_MAP[model_type].from_pretrained(
             model_path,
             model_type,

--- a/awq/models/base.py
+++ b/awq/models/base.py
@@ -90,6 +90,7 @@ TRANSFORMERS_AUTO_MAPPING_DICT = {
     "internlm2": "AutoModelForCausalLM",
     "qwen2_vl": "AutoModelForVision2Seq",
     "qwen2_5_vl": "AutoModelForVision2Seq",
+    "qwen2_5_omni": "AutoModelForTextToWaveform",
 }
 
 
@@ -377,12 +378,11 @@ class BaseAWQForCausalLM(nn.Module):
         target_cls = getattr(transformers, target_cls_name)
 
         processor = None
-        if target_cls_name == "AutoModelForVision2Seq":
+        if target_cls_name == "AutoModelForVision2Seq" or target_cls_name == "AutoModelForTextToWaveform":
             processor = AutoProcessor.from_pretrained(model_weights_path)
-
         if model_init_kwargs.get("low_cpu_mem_usage") is None:
             model_init_kwargs["low_cpu_mem_usage"] = low_cpu_mem_usage
-        if model_init_kwargs.get("use_cache") is None and target_cls_name != "AutoModelForVision2Seq":
+        if model_init_kwargs.get("use_cache") is None and not ((target_cls_name == "AutoModelForVision2Seq") or (target_cls_name == "AutoModelForTextToWaveform")):
             model_init_kwargs["use_cache"] = use_cache
 
         # If not quantized, must load with AutoModelForCausalLM

--- a/awq/models/qwen2_5_omni.py
+++ b/awq/models/qwen2_5_omni.py
@@ -1,0 +1,86 @@
+from .base import BaseAWQForCausalLM
+from typing_extensions import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from transformers.models.qwen2_5_omni.modeling_qwen2_5_omni import (
+        Qwen2_5OmniDecoderLayer
+    )
+    from transformers import Qwen2_5OmniForConditionalGeneration
+
+
+class Qwen2_5_OmniAWQForConditionalGeneration(BaseAWQForCausalLM):
+    layer_type = "Qwen2_5OmniDecoderLayer"
+    max_seq_len_key = "max_position_embeddings"
+    modules_to_not_convert = ["visual"]
+    @staticmethod
+    def get_model_layers(model: "Qwen2_5OmniForConditionalGeneration"):
+        return model.thinker.model.layers
+
+    @staticmethod
+    def get_act_for_scaling(module: "Qwen2_5OmniForConditionalGeneration"):
+        return dict(is_scalable=False)
+
+    @staticmethod
+    def move_embed(model: "Qwen2_5OmniForConditionalGeneration", device: str):
+        model.thinker.model.embed_tokens = model.thinker.model.embed_tokens.to(device)
+        model.thinker.visual = model.thinker.visual.to(device)
+        model.thinker.audio_tower = model.thinker.audio_tower.to(device)
+        
+        model.thinker.visual.rotary_pos_emb = model.thinker.visual.rotary_pos_emb.to(device)
+        model.thinker.model.rotary_emb = model.thinker.model.rotary_emb.to(device)
+        
+        for layer in model.thinker.model.layers:
+            layer.self_attn.rotary_emb = layer.self_attn.rotary_emb.to(device)
+        
+    @staticmethod
+    def get_layers_for_scaling(
+        module: "Qwen2_5OmniDecoderLayer", input_feat, module_kwargs
+    ):
+        layers = []
+
+        # attention input
+        layers.append(
+            dict(
+                prev_op=module.input_layernorm,
+                layers=[
+                    module.self_attn.q_proj,
+                    module.self_attn.k_proj,
+                    module.self_attn.v_proj,
+                ],
+                inp=input_feat["self_attn.q_proj"],
+                module2inspect=module.self_attn,
+                kwargs=module_kwargs,
+            )
+        )
+
+        # attention out
+        # Please refer to https://github.com/mit-han-lab/llm-awq/pull/67#issue-1850622696
+        if module.self_attn.v_proj.weight.shape == module.self_attn.o_proj.weight.shape:
+            layers.append(
+                dict(
+                    prev_op=module.self_attn.v_proj,
+                    layers=[module.self_attn.o_proj],
+                    inp=input_feat["self_attn.o_proj"],
+                )
+            )
+
+        # linear 1
+        layers.append(
+            dict(
+                prev_op=module.post_attention_layernorm,
+                layers=[module.mlp.gate_proj, module.mlp.up_proj],
+                inp=input_feat["mlp.gate_proj"],
+                module2inspect=module.mlp,
+            )
+        )
+
+        # linear 2
+        layers.append(
+            dict(
+                prev_op=module.mlp.up_proj,
+                layers=[module.mlp.down_proj],
+                inp=input_feat["mlp.down_proj"],
+            )
+        )
+
+        return layers

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -163,6 +163,10 @@ class AwqQuantizer:
                     self.inps, self.module_kwargs["position_ids"]
                 )
 
+            if (transformers.__version__ >= "4.48.0"
+                and self.module_kwargs.get('attention_mask') is None):
+                self.module_kwargs['attention_mask'] = None
+
             for k, v in self.module_kwargs.items():
                 # position embeddings found in tuple
                 if isinstance(v, tuple):


### PR DESCRIPTION
Add Qwen2.5-Omni support, we test on Qwen2.5-Omni-3B and Qwen2.5-Omni-7B with config:

```python
quant_config = {"zero_point": True, "q_group_size": 128, "w_bit": 4, "version": "GEMM"}
```

We have got the quantized 3B model as below:

```bash
drwxr-xr-x  2 root root 4.0K May  8 16:13 .
drwxr-xr-x 15 root root 4.0K May  8 16:28 ..
-rw-r--r--  1 root root  579 May  6 17:07 added_tokens.json
-rw-r--r--  1 root root 1.3K May  6 17:07 chat_template.jinja
-rw-r--r--  1 root root  16K May  6 17:07 config.json
-rw-r--r--  1 root root   95 May  6 17:07 generation_config.json
-rw-r--r--  1 root root 1.6M May  6 17:07 merges.txt
-rw-r--r--  1 root root 3.8G May  6 17:08 model-00001-of-00002.safetensors
-rw-r--r--  1 root root 3.7G May  6 17:08 model-00002-of-00002.safetensors
-rw-r--r--  1 root root 281K May  6 17:08 model.safetensors.index.json
-rw-r--r--  1 root root  667 May  6 17:07 preprocessor_config.json
-rw-r--r--  1 root root  833 May  6 17:07 special_tokens_map.json
-rw-r--r--  1 root root 254K May  6 14:13 spk_dict.pt
-rw-r--r--  1 root root 5.1K May  6 17:07 tokenizer_config.json
-rw-r--r--  1 root root  11M May  6 17:07 tokenizer.json
-rw-r--r--  1 root root 2.7M May  6 17:07 vocab.json
```

We also give an example to inference the quantized model with AutoAWQ:

```python
def inference_quantized_model(quant_path):
    device = get_best_device()
    model = AutoAWQForCausalLM.from_quantized(quant_path, attn_implementation="flash_attention_2")
    processor = AutoProcessor.from_pretrained(quant_path)    
    
    spk_path = quant_path + '/spk_dict.pt'
    model.model.load_speakers(spk_path)

    messages = [
        {
            "role": "system",
            "content": [
                {"type": "text", "text": "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech."}
            ],
        },
        {
            "role": "user",
            "content": [
                {"type": "image", "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg"},
                {"type": "text", "text": "generate a caption for this image"}
            ],
        },
    ]
    USE_AUDIO_IN_VIDEO = False

    text = processor.apply_chat_template(
        messages, tokenize=False, add_generation_prompt=True
    )
    audios, images, videos = process_mm_info(messages, use_audio_in_video=USE_AUDIO_IN_VIDEO)
    inputs = processor(text=text, audio=audios, images=images, videos=videos, return_tensors="pt", padding=True, use_audio_in_video=USE_AUDIO_IN_VIDEO)

    model.model.thinker.model.embed_tokens = model.model.thinker.model.embed_tokens.to(device)
    model.model.thinker.visual = model.model.thinker.visual.to(device)
    model.model.thinker.audio_tower = model.model.thinker.audio_tower.to(device)
    model.model.thinker.visual.rotary_pos_emb = model.model.thinker.visual.rotary_pos_emb.to(device)
    model.model.thinker.model.rotary_emb = model.model.thinker.model.rotary_emb.to(device)

    for layer in model.model.thinker.model.layers:
        layer.self_attn.rotary_emb = layer.self_attn.rotary_emb.to(device)

    inputs = inputs.to(device)

    return_audio = True
    if return_audio:
        text_ids, audio = model.generate(**inputs, use_audio_in_video=USE_AUDIO_IN_VIDEO, max_new_tokens=512, return_audio = True)
        sf.write(
            "output_awq_int4.wav",
            audio.reshape(-1).detach().cpu().numpy(),
            samplerate=24000,
        )
    else:
        text_ids = model.generate(**inputs, max_new_tokens=512, return_audio = False)

    text = processor.batch_decode(text_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)

    print(f'generation_output:  {text}')

```


